### PR TITLE
feat: centralize shared UI primitives

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -42,3 +42,13 @@ Border radii tokens follow `rounded-{token}`.
 - `rounded-radius-full` – fully rounded elements
 
 Refer to the components for examples of token usage.
+
+## Shared UI Components
+
+Reusable primitives are available in `src/components/ui/`:
+
+- `Button` – standard button with spacing, rounded corners, and variants for primary, secondary, and danger actions.
+- `Card` – base container with consistent border, shadow, and background.
+- `Modal` – overlay modal for confirmations and dialogs.
+
+Use these components to avoid duplicating common styles across the app.

--- a/client/src/components/DeleteConfirmationModal.jsx
+++ b/client/src/components/DeleteConfirmationModal.jsx
@@ -1,26 +1,24 @@
-import { Button, Modal } from 'flowbite-react';
 import { HiOutlineExclamationCircle } from 'react-icons/hi';
+import Button from './ui/Button';
+import Modal from './ui/Modal';
 
 export default function DeleteConfirmationModal({ isOpen, onClose, onConfirm }) {
-    return (
-        <Modal show={isOpen} size='md' onClose={onClose} popup>
-            <Modal.Header />
-            <Modal.Body>
-                <div className='text-center'>
-                    <HiOutlineExclamationCircle className='mx-auto mb-4 h-14 w-14 text-gray-400 dark:text-gray-200' />
-                    <h3 className='mb-5 text-lg font-normal text-gray-500 dark:text-gray-400'>
-                        Are you sure you want to delete this comment?
-                    </h3>
-                    <div className='flex justify-center gap-4'>
-                        <Button color='failure' onClick={onConfirm}>
-                            {"Yes, I'm sure"}
-                        </Button>
-                        <Button color='gray' onClick={onClose}>
-                            No, cancel
-                        </Button>
-                    </div>
-                </div>
-            </Modal.Body>
-        </Modal>
-    );
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className="text-center">
+        <HiOutlineExclamationCircle className="mx-auto mb-space-md h-14 w-14 text-gray-400 dark:text-gray-200" />
+        <h3 className="mb-space-md text-lg font-normal text-gray-500 dark:text-gray-400">
+          Are you sure you want to delete this comment?
+        </h3>
+        <div className="flex justify-center gap-space-md">
+          <Button variant="danger" onClick={onConfirm}>
+            {"Yes, I'm sure"}
+          </Button>
+          <Button variant="secondary" onClick={onClose}>
+            No, cancel
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
 }

--- a/client/src/components/LanguageSelector.jsx
+++ b/client/src/components/LanguageSelector.jsx
@@ -1,6 +1,7 @@
 // client/src/components/LanguageSelector.jsx
 import React from 'react';
 import { motion } from 'framer-motion';
+import Button from './ui/Button';
 
 const languages = ['html', 'css', 'javascript', 'cpp', 'python'];
 
@@ -8,13 +9,14 @@ export default function LanguageSelector({ selectedLanguage, setSelectedLanguage
     return (
         <motion.div
             layout
-            className="flex flex-wrap items-center gap-2"
+            className="flex flex-wrap items-center gap-space-sm"
         >
             {languages.map((lang) => (
-                <motion.button
+                <Button
+                    as={motion.button}
                     key={lang}
                     onClick={() => setSelectedLanguage(lang)}
-                    className={`px-4 py-2 text-sm font-semibold rounded-lg transition-colors duration-200 ${
+                    className={`text-sm font-semibold ${
                         selectedLanguage === lang
                             ? 'bg-purple-600 text-white shadow-md'
                             : 'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200 hover:bg-purple-100 dark:hover:bg-gray-600'
@@ -23,7 +25,7 @@ export default function LanguageSelector({ selectedLanguage, setSelectedLanguage
                     whileTap={{ scale: 0.95 }}
                 >
                     {lang.toUpperCase()}
-                </motion.button>
+                </Button>
             ))}
         </motion.div>
     );

--- a/client/src/components/TutorialCard.jsx
+++ b/client/src/components/TutorialCard.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { motion, useMotionValue, useSpring, useTransform } from 'framer-motion';
 import { useState, useRef } from 'react';
+import Card from './ui/Card';
 
 const TutorialCard = ({ tutorial }) => {
     // Define animation variants for the card's entrance
@@ -43,9 +44,10 @@ const TutorialCard = ({ tutorial }) => {
 
     return (
         <Link to={`/tutorials/${tutorial.slug}`} className="block h-full">
-            <motion.div
+            <Card
+                as={motion.div}
                 ref={cardRef}
-                className="relative border border-gray-700 rounded-lg shadow-md overflow-hidden h-full flex flex-col bg-gray-800"
+                className="relative overflow-hidden h-full flex flex-col"
                 variants={cardVariants}
                 initial="hidden"
                 whileInView="visible"
@@ -85,7 +87,7 @@ const TutorialCard = ({ tutorial }) => {
                         </span>
                     </div>
                 </div>
-            </motion.div>
+            </Card>
         </Link>
     );
 };

--- a/client/src/components/ui/Button.jsx
+++ b/client/src/components/ui/Button.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const Button = React.forwardRef(({ as: Component = 'button', variant = 'primary', className = '', ...props }, ref) => {
+  const base = 'px-space-md py-space-sm rounded-radius-md font-medium transition-colors duration-200 focus:outline-none';
+  const variants = {
+    primary: 'bg-professional-blue-600 text-white hover:bg-professional-blue-700',
+    secondary: 'bg-subtle-gray-200 text-gray-800 hover:bg-subtle-gray-300',
+    danger: 'bg-red-600 text-white hover:bg-red-700',
+  };
+  const variantClasses = variants[variant] || '';
+  return (
+    <Component ref={ref} className={`${base} ${variantClasses} ${className}`} {...props} />
+  );
+});
+
+export default Button;

--- a/client/src/components/ui/Card.jsx
+++ b/client/src/components/ui/Card.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Card = React.forwardRef(({ as: Component = 'div', className = '', ...props }, ref) => (
+  <Component
+    ref={ref}
+    className={`bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-radius-lg shadow-md ${className}`}
+    {...props}
+  />
+));
+
+export default Card;

--- a/client/src/components/ui/Modal.jsx
+++ b/client/src/components/ui/Modal.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function Modal({ isOpen, onClose, children }) {
+  if (!isOpen) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+      <div
+        className="bg-white dark:bg-gray-800 rounded-radius-lg shadow-lg p-space-lg max-w-md w-full"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add shared Button, Card, and Modal primitives
- refactor DeleteConfirmationModal, TutorialCard, and LanguageSelector to use new primitives
- document shared UI components

## Testing
- `npm run lint --prefix client` *(fails: Spinner is defined but never used, Radio is defined but never used, useState is defined but never used, useEffect is defined but never used, quizData is assigned a value but never used, `"` can be escaped with `&quot;`, `&ldquo;`, `&#34;`, `&rdquo;`, useRef is defined but never used, CircularProgressbar is not defined, `"` can be escaped with `&quot;`, `&ldquo;`, `&#34;`, `&rdquo;`)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c7f3f120f4832d848d3a8398ed2d4b