### PR TITLE
feat: add dark mode variants to components

### DIFF
--- a/client/src/components/CallToAction.jsx
+++ b/client/src/components/CallToAction.jsx
@@ -2,13 +2,13 @@ import { Button } from 'flowbite-react';
 
 export default function CallToAction() {
   return (
-      <div className='flex border border-teal-500 p-3 justify-center items-center rounded-tl-3xl rounded-br-3xl flex-col sm:flex-row text-center'>
+      <div className='flex border border-teal-500 dark:border-teal-400 p-3 justify-center items-center rounded-tl-3xl rounded-br-3xl flex-col sm:flex-row text-center'>
         <div className='flex-1 justify-center flex flex-col'>
           <h2 className='text-2xl'>
             Want to learn HTML, CSS and JavaScript by building fun and engaging
             projects?
           </h2>
-          <p className='text-gray-500 my-2'>
+          <p className='text-gray-500 dark:text-gray-400 my-2'>
             Check our 100 js projects website and start building your own projects
           </p>
           <a

--- a/client/src/components/Comment.jsx
+++ b/client/src/components/Comment.jsx
@@ -72,7 +72,7 @@ export default function Comment({ comment, onLike, onEdit, onDelete }) {
         >
           <div className='flex-shrink-0 mr-3'>
             <img
-                className='w-10 h-10 rounded-full bg-gray-200 object-cover'
+                className='w-10 h-10 rounded-full bg-gray-200 dark:bg-gray-700 object-cover'
                 src={user?.profilePicture}
                 alt={user?.username}
             />
@@ -82,7 +82,7 @@ export default function Comment({ comment, onLike, onEdit, onDelete }) {
             <span className='font-bold mr-1 text-xs truncate'>
               {user ? `@${user.username}` : 'anonymous user'}
             </span>
-              <span className='text-gray-500 text-xs'>
+              <span className='text-gray-500 dark:text-gray-400 text-xs'>
               {moment(comment.createdAt).fromNow()}
             </span>
             </div>
@@ -116,19 +116,19 @@ export default function Comment({ comment, onLike, onEdit, onDelete }) {
                 </>
             ) : (
                 <>
-                  <p className='text-gray-500 pb-2 break-words'>{comment.content}</p>
+                  <p className='text-gray-500 dark:text-gray-300 pb-2 break-words'>{comment.content}</p>
                   <div className='flex items-center pt-2 text-xs border-t dark:border-gray-700 max-w-fit gap-4'>
                     <button
                         type='button'
                         onClick={() => onLike(comment._id)}
-                        className={`text-gray-500 hover:text-blue-500 flex items-center gap-1 ${
+                        className={`text-gray-500 dark:text-gray-400 hover:text-blue-500 dark:hover:text-blue-400 flex items-center gap-1 ${
                             currentUser &&
                             comment.likes.includes(currentUser._id) &&
-                            'text-blue-500'
+                            'text-blue-500 dark:text-blue-400'
                         }`}
                     >
                       <FaThumbsUp className='text-sm' />
-                      <span className='text-gray-400'>
+                      <span className='text-gray-400 dark:text-gray-500'>
                     {comment.numberOfLikes > 0 &&
                         comment.numberOfLikes}
                   </span>
@@ -140,14 +140,14 @@ export default function Comment({ comment, onLike, onEdit, onDelete }) {
                               <button
                                   type='button'
                                   onClick={handleEdit}
-                                  className='text-gray-500 hover:text-blue-500'
+                                  className='text-gray-500 dark:text-gray-400 hover:text-blue-500 dark:hover:text-blue-400'
                               >
                                 <FaEdit />
                               </button>
                               <button
                                   type='button'
                                   onClick={() => setShowDeleteModal(true)}
-                                  className='text-gray-500 hover:text-red-500'
+                                  className='text-gray-500 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400'
                               >
                                 <FaTrashAlt />
                               </button>

--- a/client/src/components/CommentSection.jsx
+++ b/client/src/components/CommentSection.jsx
@@ -112,7 +112,7 @@ export default function CommentSection({ postId }) {
   return (
       <div className='max-w-2xl mx-auto w-full p-3'>
         {currentUser ? (
-            <div className='flex items-center gap-1 my-5 text-gray-500 text-sm'>
+            <div className='flex items-center gap-1 my-5 text-gray-500 dark:text-gray-400 text-sm'>
               <p>Signed in as:</p>
               <img
                   className='h-5 w-5 object-cover rounded-full'
@@ -121,15 +121,15 @@ export default function CommentSection({ postId }) {
               />
               <Link
                   to={'/dashboard?tab=profile'}
-                  className='text-xs text-cyan-600 hover:underline'
+                  className='text-xs text-cyan-600 dark:text-cyan-400 hover:underline'
               >
                 @{currentUser.username}
               </Link>
             </div>
         ) : (
-            <div className='text-sm text-teal-500 my-5 flex gap-1'>
+            <div className='text-sm text-teal-500 dark:text-teal-400 my-5 flex gap-1'>
               You must be signed in to comment.
-              <Link className='text-blue-500 hover:underline' to={'/sign-in'}>
+              <Link className='text-blue-500 dark:text-blue-400 hover:underline' to={'/sign-in'}>
                 Sign In
               </Link>
             </div>
@@ -147,7 +147,7 @@ export default function CommentSection({ postId }) {
                   value={comment}
               />
               <div className='flex justify-between items-center mt-5'>
-                <p className='text-gray-500 text-xs'>
+                <p className='text-gray-500 dark:text-gray-400 text-xs'>
                   {200 - comment.length} characters remaining
                 </p>
                 <Button outline gradientDuoTone='purpleToBlue' type='submit'>
@@ -162,12 +162,12 @@ export default function CommentSection({ postId }) {
             </form>
         )}
         {comments.length === 0 ? (
-            <p className='text-sm my-5'>No comments yet!</p>
+            <p className='text-sm my-5 text-gray-600 dark:text-gray-300'>No comments yet!</p>
         ) : (
             <>
               <div className='text-sm my-5 flex items-center gap-1'>
                 <p>Comments</p>
-                <div className='border border-gray-400 py-1 px-2 rounded-sm'>
+                <div className='border border-gray-400 dark:border-gray-600 py-1 px-2 rounded-sm'>
                   <p>{comments.length}</p>
                 </div>
               </div>

--- a/client/src/components/DraggableChapter.jsx
+++ b/client/src/components/DraggableChapter.jsx
@@ -72,10 +72,14 @@ const DraggableChapter = ({
 
     const renderContentTypeIcon = (type) => {
         switch (type) {
-            case 'text': return <FaBook className="text-teal-500" />;
-            case 'code-interactive': return <FaCode className="text-blue-500" />;
-            case 'quiz': return <FaList className="text-purple-500" />;
-            default: return null;
+            case 'text':
+                return <FaBook className="text-teal-500 dark:text-teal-400" />;
+            case 'code-interactive':
+                return <FaCode className="text-blue-500 dark:text-blue-400" />;
+            case 'quiz':
+                return <FaList className="text-purple-500 dark:text-purple-400" />;
+            default:
+                return null;
         }
     };
 
@@ -99,7 +103,7 @@ const DraggableChapter = ({
                             <div className='flex items-center gap-2'>
                                 <p className="text-sm font-semibold text-gray-700 dark:text-gray-300">Initial Code</p>
                                 <Tooltip content="This code will be displayed in the interactive editor for the user to start with.">
-                                    <FaQuestionCircle className="text-gray-400 cursor-help" />
+                                    <FaQuestionCircle className="text-gray-400 dark:text-gray-500 cursor-help" />
                                 </Tooltip>
                             </div>
                             <Textarea
@@ -113,7 +117,7 @@ const DraggableChapter = ({
                             <div className='flex items-center gap-2'>
                                 <p className="text-sm font-semibold text-gray-700 dark:text-gray-300">Expected Output</p>
                                 <Tooltip content="The expected output of the code. This will be used to validate the user's solution. Leave blank if not needed.">
-                                    <FaQuestionCircle className="text-gray-400 cursor-help" />
+                                    <FaQuestionCircle className="text-gray-400 dark:text-gray-500 cursor-help" />
                                 </Tooltip>
                             </div>
                             <TextInput

--- a/client/src/components/Hero.jsx
+++ b/client/src/components/Hero.jsx
@@ -53,14 +53,14 @@ export default function Hero() {
                     <TextInput
                         type="text"
                         placeholder="Search for tutorials..."
-                        className="flex-grow rounded-l-radius-full [&>div>input]:!rounded-none [&>div>input]:!border-0 [&>div>input]:!ring-0 [&>div>input]:!shadow-none [&>div>input]:bg-white/90 [&>div>input]:placeholder-gray-500 [&>div>input]:text-gray-900 focus:!ring-0"
+                        className="flex-grow rounded-l-radius-full [&>div>input]:!rounded-none [&>div>input]:!border-0 [&>div>input]:!ring-0 [&>div>input]:!shadow-none [&>div>input]:bg-white/90 dark:[&>div>input]:bg-gray-800/90 [&>div>input]:placeholder-gray-500 dark:[&>div>input]:placeholder-gray-400 [&>div>input]:text-gray-900 dark:[&>div>input]:text-gray-100 focus:!ring-0"
                         value={searchQuery}
                         onChange={(e) => setSearchQuery(e.target.value)}
                         icon={HiMagnifyingGlass}
                     />
                     <Button
                         type="submit"
-                        className="bg-sky-500 hover:bg-sky-600 text-white !rounded-none rounded-r-radius-full h-11 w-20 transition-colors duration-300 transform hover:scale-105"
+                        className="bg-sky-500 hover:bg-sky-600 dark:bg-sky-600 dark:hover:bg-sky-500 text-white !rounded-none rounded-r-radius-full h-11 w-20 transition-colors duration-300 transform hover:scale-105"
                     >
                         Go
                     </Button>

--- a/client/src/components/InteractiveCodeBlock.jsx
+++ b/client/src/components/InteractiveCodeBlock.jsx
@@ -59,7 +59,7 @@ export default function InteractiveCodeBlock({ initialCode, language }) {
         >
             <div className="flex justify-between items-center pb-4 border-b border-gray-200 dark:border-gray-700">
                 <h3 className="text-xl font-bold flex items-center gap-3 text-gray-800 dark:text-gray-100">
-                    <FaCode className="text-purple-600 drop-shadow-md" /> Interactive Code
+                    <FaCode className="text-purple-600 dark:text-purple-400 drop-shadow-md" /> Interactive Code
                 </h3>
                 <motion.div {...motionWrapperProps}>
                     <Button
@@ -106,7 +106,7 @@ export default function InteractiveCodeBlock({ initialCode, language }) {
                         className="pt-6"
                     >
                         <div className="w-full relative group">
-                            <pre className={`p-5 rounded-lg bg-gray-900 text-white language-${language} overflow-x-auto text-sm shadow-inner`}>
+                            <pre className={`p-5 rounded-lg bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-white language-${language} overflow-x-auto text-sm shadow-inner`}>
                                 <code dangerouslySetInnerHTML={{ __html: initialCode }} />
                             </pre>
                             <motion.div


### PR DESCRIPTION
## Summary
- add complementary dark: color classes to call-to-action banner
- improve hero search styling for dark theme
- adjust code block, chapter editor, and comment components for dark mode contrast

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars, react/no-unescaped-entities, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c7f8040870832d8c1386b41ab0c78d