### PR TITLE
feat(ui): add mobile bottom navigation with theme toggle

### DIFF
--- a/client/src/components/BottomNav.jsx
+++ b/client/src/components/BottomNav.jsx
@@ -1,0 +1,55 @@
+import { Link, useLocation } from 'react-router-dom';
+import { FaBook, FaHome, FaQuestionCircle, FaUser } from 'react-icons/fa';
+import { useSelector } from 'react-redux';
+import { motion } from 'framer-motion';
+import ThemeToggle from './ThemeToggle';
+
+const items = [
+  { to: '/', label: 'Home', icon: FaHome },
+  { to: '/tutorials', label: 'Tutorials', icon: FaBook },
+  { to: '/quizzes', label: 'Quizzes', icon: FaQuestionCircle }
+];
+
+export default function BottomNav() {
+  const { currentUser } = useSelector((state) => state.user);
+  const location = useLocation();
+
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 md:hidden z-50">
+      <ul className="flex justify-around items-center p-2">
+        {items.map(({ to, label, icon: Icon }) => {
+          const active = location.pathname === to;
+          return (
+            <li key={to}>
+              <Link to={to} aria-label={label}>
+                <motion.div
+                  whileTap={{ scale: 0.9 }}
+                  className={`flex flex-col items-center text-xs ${active ? 'text-cyan-600 dark:text-cyan-400' : 'text-gray-500 dark:text-gray-400'}`}
+                >
+                  <Icon className="text-xl" />
+                  <span className="mt-1">{label}</span>
+                </motion.div>
+              </Link>
+            </li>
+          );
+        })}
+        {currentUser && (
+          <li>
+            <Link to="/dashboard" aria-label="Dashboard">
+              <motion.div
+                whileTap={{ scale: 0.9 }}
+                className={`flex flex-col items-center text-xs ${location.pathname.startsWith('/dashboard') ? 'text-cyan-600 dark:text-cyan-400' : 'text-gray-500 dark:text-gray-400'}`}
+              >
+                <FaUser className="text-xl" />
+                <span className="mt-1">Dashboard</span>
+              </motion.div>
+            </Link>
+          </li>
+        )}
+        <li>
+          <ThemeToggle />
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -3,13 +3,12 @@
 import { Avatar, Button, Navbar, TextInput, Tooltip, Modal } from 'flowbite-react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { AiOutlineSearch } from 'react-icons/ai';
-import { FaMoon, FaSun } from 'react-icons/fa';
 import { useSelector, useDispatch } from 'react-redux';
 import { motion, AnimatePresence, useScroll, useMotionValueEvent } from 'framer-motion';
 import { useEffect, useState, useRef } from 'react';
 
-import { toggleTheme } from '../redux/theme/themeSlice';
 import { signoutSuccess } from '../redux/user/userSlice';
+import ThemeToggle from './ThemeToggle';
 
 // --- Magnetic, CommandMenu, and navLinks components have no changes ---
 // (They are included below for completeness)
@@ -273,13 +272,7 @@ export default function Header() {
                 </Magnetic>
                 <Magnetic>
                   <Tooltip content="Toggle Theme">
-                    <Button className='w-12 h-10 hidden sm:inline' color='gray' pill onClick={() => dispatch(toggleTheme())}>
-                      <AnimatePresence mode='wait' initial={false}>
-                        <motion.span key={theme} initial={{ y: -20, opacity: 0 }} animate={{ y: 0, opacity: 1 }} exit={{ y: 20, opacity: 0 }} transition={{ duration: 0.2 }}>
-                          {theme === 'light' ? <FaSun /> : <FaMoon />}
-                        </motion.span>
-                      </AnimatePresence>
-                    </Button>
+                    <ThemeToggle className='hidden sm:inline-flex w-12 h-10' />
                   </Tooltip>
                 </Magnetic>
                 {currentUser ? (

--- a/client/src/components/MainLayout.jsx
+++ b/client/src/components/MainLayout.jsx
@@ -2,6 +2,7 @@ import { Outlet } from 'react-router-dom';
 import Header from './Header';
 import Footer from './Footer';
 import ScrollToTop from './ScrollToTop';
+import BottomNav from './BottomNav';
 
 /**
  * Renders the common layout for the application, including the
@@ -17,6 +18,7 @@ export default function MainLayout() {
                 <Outlet />
             </main>
             <Footer />
+            <BottomNav />
         </>
     );
 }

--- a/client/src/components/ThemeToggle.jsx
+++ b/client/src/components/ThemeToggle.jsx
@@ -1,0 +1,27 @@
+import { FaMoon, FaSun } from 'react-icons/fa';
+import { useDispatch, useSelector } from 'react-redux';
+import { toggleTheme } from '../redux/theme/themeSlice';
+import { motion } from 'framer-motion';
+
+/**
+ * Small reusable button that toggles the application's theme.
+ * The current theme is persisted in localStorage via the redux slice.
+ *
+ * Usage:
+ * <ThemeToggle className="w-10 h-10" />
+ */
+export default function ThemeToggle({ className = '' }) {
+  const dispatch = useDispatch();
+  const { theme } = useSelector((state) => state.theme);
+
+  return (
+    <motion.button
+      whileTap={{ scale: 0.9 }}
+      onClick={() => dispatch(toggleTheme())}
+      className={`flex items-center justify-center rounded-full bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200 focus:outline-none ${className}`}
+      aria-label="Toggle theme"
+    >
+      {theme === 'light' ? <FaMoon /> : <FaSun />}
+    </motion.button>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `ThemeToggle` component persisting theme selection
- introduce responsive `BottomNav` for mobile with animated links and theme switcher
- update header and layout to use new components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 389 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c81add7bfc832d9a2b02b69f73b2ab