### PR TITLE
Refactor auth and user controllers to use services

### DIFF
--- a/api/services/auth.service.js
+++ b/api/services/auth.service.js
@@ -1,0 +1,22 @@
+import User from '../models/user.model.js';
+
+/**
+ * Creates and persists a new user document.
+ *
+ * @param {Object} userData - Data used to create the user.
+ * @returns {Promise<Object>} The saved user document.
+ */
+export const createUser = async (userData) => {
+  const newUser = new User(userData);
+  return await newUser.save();
+};
+
+/**
+ * Finds a user by email address.
+ *
+ * @param {string} email - The email to search for.
+ * @returns {Promise<Object|null>} The matching user document or null.
+ */
+export const findUserByEmail = (email) => {
+  return User.findOne({ email });
+};

--- a/api/services/user.service.js
+++ b/api/services/user.service.js
@@ -1,0 +1,93 @@
+import User from '../models/user.model.js';
+
+/**
+ * Retrieves a user by ID.
+ *
+ * @param {string} userId - The user identifier.
+ * @param {Object} [options]
+ * @param {boolean} [options.excludePassword=false] - Exclude the password field from the result.
+ * @returns {Promise<Object|null>} The user document or null if not found.
+ */
+export const getUserById = (userId, { excludePassword = false } = {}) => {
+  const query = User.findById(userId);
+  if (excludePassword) {
+    query.select('-password');
+  }
+  return query;
+};
+
+/**
+ * Updates a user's properties and saves the document.
+ *
+ * @param {string} userId - The user identifier.
+ * @param {Object} updates - Fields to update.
+ * @returns {Promise<Object|null>} The updated user document or null if not found.
+ */
+export const updateUserById = async (userId, updates) => {
+  const userToUpdate = await User.findById(userId);
+  if (!userToUpdate) {
+    return null;
+  }
+
+  if (updates.username) {
+    userToUpdate.username = updates.username;
+  }
+  if (updates.email) {
+    userToUpdate.email = updates.email;
+  }
+  if (updates.password) {
+    userToUpdate.password = updates.password;
+  }
+  if (updates.profilePicture) {
+    userToUpdate.profilePicture = updates.profilePicture;
+  }
+
+  return await userToUpdate.save();
+};
+
+/**
+ * Deletes a user by ID.
+ *
+ * @param {string} userId - The user identifier.
+ * @returns {Promise<Object|null>} The result of the deletion operation.
+ */
+export const deleteUserById = (userId) => {
+  return User.findByIdAndDelete(userId);
+};
+
+/**
+ * Retrieves users with pagination and sorting.
+ *
+ * @param {number} startIndex - Number of records to skip.
+ * @param {number} limit - Number of records to return.
+ * @param {number} sortDirection - Sort direction (1 for asc, -1 for desc).
+ * @returns {Promise<Array>} The list of users.
+ */
+export const findUsersWithPagination = (startIndex, limit, sortDirection) => {
+  return User.find()
+      .sort({ createdAt: sortDirection })
+      .skip(startIndex)
+      .limit(limit)
+      .select('-password');
+};
+
+/**
+ * Counts all users in the collection.
+ *
+ * @returns {Promise<number>} The number of users.
+ */
+export const countAllUsers = () => {
+  return User.countDocuments();
+};
+
+/**
+ * Counts users created after a specific date.
+ *
+ * @param {Date} date - The start date.
+ * @returns {Promise<number>} The number of users created after the date.
+ */
+export const countUsersCreatedAfter = (date) => {
+  return User.countDocuments({
+    createdAt: { $gte: date },
+  });
+};


### PR DESCRIPTION
## Summary
- add dedicated auth and user service modules to encapsulate user model interactions
- update auth and user controllers to delegate persistence logic to the new services

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68c8d14a2dcc832d89439c5b18a8524d