### PR TITLE
Fix dark theme overrides to target root element

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -66,8 +66,8 @@ html {
 /*
  * --- Dark Theme Overrides ---
  * Redefines the color variables for a professional dark theme.
- */
-.dark :root {
+*/
+:root.dark {
   --color-bg-primary: #143859; /* Dark blue from professional-blue-900 */
   --color-bg-secondary: #174878; /* Deeper blue from professional-blue-800 */
   --color-text-primary: #e0eeff; /* Light blue from professional-blue-100 */


### PR DESCRIPTION
## Summary
- update the dark theme CSS variable override to target the root element when the `dark` class is present

## Testing
- npm run build --prefix client
- Manual theme toggle verification

------
https://chatgpt.com/codex/tasks/task_b_68cac4d14d44832d90379d68cec31eda