### PR TITLE
Handle missing quiz questions array

### DIFF
--- a/api/controllers/quiz.controller.js
+++ b/api/controllers/quiz.controller.js
@@ -17,7 +17,7 @@ export const createQuiz = async (req, res, next) => {
     }
     const { title, description, category, questions, relatedTutorials } = req.body;
 
-    if (!title || questions.length === 0) {
+    if (!title || !Array.isArray(questions) || questions.length === 0) {
         return next(errorHandler(400, 'Please provide quiz title and at least one question.'));
     }
 

--- a/api/controllers/quiz.controller.test.js
+++ b/api/controllers/quiz.controller.test.js
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createQuiz } from './quiz.controller.js';
+
+const mockResponse = () => {
+    const res = {};
+    res.status = function status() {
+        return this;
+    };
+    res.json = function json() {
+        return this;
+    };
+    return res;
+};
+
+test('createQuiz returns 400 error when questions are missing', async () => {
+    const req = {
+        user: { isAdmin: true, id: 'user-id' },
+        body: { title: 'Sample Quiz' },
+    };
+    const res = mockResponse();
+
+    let nextCalledWith;
+    const next = (err) => {
+        nextCalledWith = err;
+    };
+
+    await createQuiz(req, res, next);
+
+    assert.ok(nextCalledWith instanceof Error, 'Expected next to be called with an error');
+    assert.equal(nextCalledWith.statusCode, 400);
+    assert.equal(
+        nextCalledWith.message,
+        'Please provide quiz title and at least one question.'
+    );
+});
+
+test('createQuiz returns 400 error when questions array is empty', async () => {
+    const req = {
+        user: { isAdmin: true, id: 'user-id' },
+        body: { title: 'Sample Quiz', questions: [] },
+    };
+    const res = mockResponse();
+
+    let nextCalledWith;
+    const next = (err) => {
+        nextCalledWith = err;
+    };
+
+    await createQuiz(req, res, next);
+
+    assert.ok(nextCalledWith instanceof Error, 'Expected next to be called with an error');
+    assert.equal(nextCalledWith.statusCode, 400);
+    assert.equal(
+        nextCalledWith.message,
+        'Please provide quiz title and at least one question.'
+    );
+});


### PR DESCRIPTION
## Summary
- guard the quiz creation controller against missing or non-array question payloads
- add unit tests that ensure createQuiz returns a 400 error when questions are missing or empty

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cae27474a0832dacf2c542564c9f69