### PR TITLE
Allow configuring client API base URL

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,3 @@
+# Base URL for API requests issued by the Vite client.
+# Leave empty to default to same-origin relative paths.
+VITE_API_URL=http://localhost:3000

--- a/client/README.md
+++ b/client/README.md
@@ -52,3 +52,17 @@ Reusable primitives are available in `src/components/ui/`:
 - `Modal` – overlay modal for confirmations and dialogs.
 
 Use these components to avoid duplicating common styles across the app.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` in the project root to customize how the client connects to the API. The following variable is available:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `VITE_API_URL` | _(empty)_ | Optional base URL for all API requests. Leave unset to use same-origin relative paths, or set it to an absolute URL such as `http://localhost:3000` when the backend is hosted elsewhere. |
+
+Example `.env` snippet:
+
+```bash
+VITE_API_URL=http://localhost:3000
+```

--- a/client/src/services/quizService.js
+++ b/client/src/services/quizService.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 
 // Create an Axios instance with a base URL and credentials
 const API = axios.create({
-    baseURL: "http://localhost:3000",
+    baseURL: import.meta.env.VITE_API_URL ?? '',
     // CRITICAL FIX: This sends cookies with every request
     withCredentials: true,
 });

--- a/client/src/services/tutorialService.js
+++ b/client/src/services/tutorialService.js
@@ -4,7 +4,7 @@ import axios from 'axios';
 // Create an Axios instance with a base URL and credentials
 // This instance will automatically include cookies in every request
 const API = axios.create({
-    baseURL: "http://localhost:3000",
+    baseURL: import.meta.env.VITE_API_URL ?? '',
     withCredentials: true,
 });
 


### PR DESCRIPTION
## Summary
- allow the quiz and tutorial service axios clients to pick up a configurable base URL via `VITE_API_URL`
- document the new environment variable and provide an example `.env` file for non-default deployments

## Testing
- npm run lint *(fails: existing lint issues in unrelated components)*
- VITE_API_URL=https://api.dev.local npm run dev -- --host *(smoke test startup only)*
- VITE_API_URL=https://api.example.com npm run build *(fails: existing CSS @import ordering error)*

------
https://chatgpt.com/codex/tasks/task_b_68cb66eb0c7c832d82e9c936d79cdc39