### PR TITLE
feat: add content management system for custom pages

### DIFF
--- a/api/controllers/page.controller.js
+++ b/api/controllers/page.controller.js
@@ -1,0 +1,335 @@
+import Page from '../models/page.model.js';
+import { errorHandler } from '../utils/error.js';
+import slugify from '../utils/slugify.js';
+
+const allowedSectionTypes = new Set(['hero', 'rich-text', 'feature-grid', 'cta', 'custom']);
+const allowedAlignments = new Set(['left', 'center', 'right']);
+
+const sanitizeSections = (sections = []) => {
+    if (!Array.isArray(sections)) {
+        return [];
+    }
+
+    const sanitized = sections
+        .map((section, index) => {
+            if (!section || typeof section !== 'object') {
+                return null;
+            }
+
+            const type = allowedSectionTypes.has(section.type) ? section.type : 'rich-text';
+            const title = section.title?.toString().trim() ?? '';
+            const subtitle = section.subtitle?.toString().trim() ?? '';
+            const body = section.body?.toString().trim() ?? '';
+            const alignment = allowedAlignments.has(section.alignment) ? section.alignment : 'left';
+            const background = section.background?.toString().trim() || 'default';
+            const order = Number.isFinite(Number(section.order)) ? Number(section.order) : index;
+
+            const mediaUrl = section.media?.url ?? section.mediaUrl;
+            const mediaAlt = section.media?.alt ?? section.mediaAlt;
+
+            const ctaLabel = section.cta?.label ?? section.ctaLabel;
+            const ctaUrl = section.cta?.url ?? section.ctaUrl;
+
+            const items = Array.isArray(section.items)
+                ? section.items
+                      .map((item) => ({
+                          title: item?.title?.toString().trim() ?? '',
+                          body: item?.body?.toString().trim() ?? '',
+                          icon: item?.icon?.toString().trim() ?? '',
+                      }))
+                      .filter((item) => item.title || item.body || item.icon)
+                : [];
+
+            const shouldKeep =
+                title ||
+                subtitle ||
+                body ||
+                items.length > 0 ||
+                ctaLabel ||
+                ctaUrl ||
+                mediaUrl;
+
+            if (!shouldKeep) {
+                return null;
+            }
+
+            const sanitizedSection = {
+                type,
+                title,
+                subtitle,
+                body,
+                alignment,
+                background,
+                order,
+            };
+
+            if (items.length > 0) {
+                sanitizedSection.items = items;
+            }
+
+            if (mediaUrl || mediaAlt) {
+                sanitizedSection.media = {
+                    url: mediaUrl?.toString().trim() ?? '',
+                    alt: mediaAlt?.toString().trim() ?? '',
+                };
+            }
+
+            if (ctaLabel || ctaUrl) {
+                sanitizedSection.cta = {
+                    label: ctaLabel?.toString().trim() ?? '',
+                    url: ctaUrl?.toString().trim() ?? '',
+                };
+            }
+
+            return sanitizedSection;
+        })
+        .filter(Boolean)
+        .sort((a, b) => a.order - b.order)
+        .map((section, index) => ({ ...section, order: index }));
+
+    return sanitized;
+};
+
+const normalizeKeywords = (keywords) => {
+    if (Array.isArray(keywords)) {
+        return keywords.map((keyword) => keyword?.toString().trim()).filter(Boolean);
+    }
+
+    if (typeof keywords === 'string') {
+        return keywords
+            .split(',')
+            .map((keyword) => keyword.trim())
+            .filter(Boolean);
+    }
+
+    return [];
+};
+
+const sortSections = (sections = []) =>
+    [...sections].sort((a, b) => (Number(a.order) || 0) - (Number(b.order) || 0));
+
+export const createPage = async (req, res, next) => {
+    try {
+        if (!req.user?.isAdmin) {
+            return next(errorHandler(403, 'Only administrators can create content pages.'));
+        }
+
+        const { title, slug, description, sections, status = 'draft', seo = {} } = req.body;
+
+        if (!title?.toString().trim()) {
+            return next(errorHandler(400, 'Title is required.'));
+        }
+
+        const normalizedSlug = slugify(slug || title);
+        const existingPage = await Page.findOne({ slug: normalizedSlug });
+
+        if (existingPage) {
+            return next(errorHandler(409, 'A page with this slug already exists.'));
+        }
+
+        const sanitizedSections = sanitizeSections(sections);
+        const normalizedStatus = status === 'published' ? 'published' : 'draft';
+
+        const page = await Page.create({
+            title: title.trim(),
+            slug: normalizedSlug,
+            description: description?.toString().trim() ?? '',
+            status: normalizedStatus,
+            publishedAt: normalizedStatus === 'published' ? new Date() : undefined,
+            sections: sanitizedSections,
+            seo: {
+                metaTitle: seo.metaTitle?.toString().trim() || title.trim(),
+                metaDescription: seo.metaDescription?.toString().trim() || description?.toString().trim() || '',
+                keywords: normalizeKeywords(seo.keywords),
+            },
+            createdBy: req.user.id,
+            updatedBy: req.user.id,
+        });
+
+        const pageObject = page.toObject();
+        pageObject.sections = sortSections(pageObject.sections);
+
+        res.status(201).json(pageObject);
+    } catch (error) {
+        next(error);
+    }
+};
+
+export const getPages = async (req, res, next) => {
+    try {
+        if (!req.user?.isAdmin) {
+            return next(errorHandler(403, 'Only administrators can view content pages.'));
+        }
+
+        const startIndex = Math.max(parseInt(req.query.startIndex, 10) || 0, 0);
+        const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 10, 1), 50);
+        const status = req.query.status;
+        const searchTerm = req.query.searchTerm?.toString().trim();
+
+        const filters = {};
+
+        if (status && status !== 'all') {
+            filters.status = status;
+        }
+
+        if (searchTerm) {
+            filters.$or = [
+                { title: { $regex: searchTerm, $options: 'i' } },
+                { slug: { $regex: searchTerm, $options: 'i' } },
+            ];
+        }
+
+        const lastMonthDate = new Date();
+        lastMonthDate.setMonth(lastMonthDate.getMonth() - 1);
+
+        const [pages, totalCount, lastMonthCount] = await Promise.all([
+            Page.find(filters)
+                .sort({ updatedAt: -1 })
+                .skip(startIndex)
+                .limit(limit)
+                .lean(),
+            Page.countDocuments(filters),
+            Page.countDocuments({ ...filters, createdAt: { $gte: lastMonthDate } }),
+        ]);
+
+        const normalizedPages = pages.map((page) => ({
+            ...page,
+            sections: sortSections(page.sections ?? []),
+        }));
+
+        res.status(200).json({
+            pages: normalizedPages,
+            totalCount,
+            lastMonthCount,
+            limit,
+            nextIndex: startIndex + normalizedPages.length,
+            hasMore: startIndex + normalizedPages.length < totalCount,
+        });
+    } catch (error) {
+        next(error);
+    }
+};
+
+export const getPageById = async (req, res, next) => {
+    try {
+        if (!req.user?.isAdmin) {
+            return next(errorHandler(403, 'Only administrators can view content pages.'));
+        }
+
+        const page = await Page.findById(req.params.pageId).lean();
+
+        if (!page) {
+            return next(errorHandler(404, 'Page not found.'));
+        }
+
+        page.sections = sortSections(page.sections ?? []);
+
+        res.status(200).json(page);
+    } catch (error) {
+        next(error);
+    }
+};
+
+export const updatePage = async (req, res, next) => {
+    try {
+        if (!req.user?.isAdmin) {
+            return next(errorHandler(403, 'Only administrators can update content pages.'));
+        }
+
+        const page = await Page.findById(req.params.pageId);
+
+        if (!page) {
+            return next(errorHandler(404, 'Page not found.'));
+        }
+
+        const { title, slug, description, sections, status, seo = {} } = req.body;
+
+        if (!title?.toString().trim()) {
+            return next(errorHandler(400, 'Title is required.'));
+        }
+
+        const normalizedSlug = slugify(slug || title);
+
+        if (normalizedSlug !== page.slug) {
+            const slugExists = await Page.findOne({ slug: normalizedSlug, _id: { $ne: page._id } });
+            if (slugExists) {
+                return next(errorHandler(409, 'A page with this slug already exists.'));
+            }
+        }
+
+        const sanitizedSections = sanitizeSections(sections);
+        const normalizedStatus = status === 'published' ? 'published' : 'draft';
+
+        page.title = title.trim();
+        page.slug = normalizedSlug;
+        page.description = description?.toString().trim() ?? '';
+        page.status = normalizedStatus;
+        page.sections = sanitizedSections;
+        page.seo = {
+            metaTitle: seo.metaTitle?.toString().trim() || title.trim(),
+            metaDescription: seo.metaDescription?.toString().trim() || description?.toString().trim() || '',
+            keywords: normalizeKeywords(seo.keywords),
+        };
+        page.updatedBy = req.user.id;
+
+        if (normalizedStatus === 'published' && !page.publishedAt) {
+            page.publishedAt = new Date();
+        }
+
+        if (normalizedStatus === 'draft') {
+            page.publishedAt = undefined;
+        }
+
+        await page.save();
+
+        const pageObject = page.toObject();
+        pageObject.sections = sortSections(pageObject.sections);
+
+        res.status(200).json(pageObject);
+    } catch (error) {
+        next(error);
+    }
+};
+
+export const deletePage = async (req, res, next) => {
+    try {
+        if (!req.user?.isAdmin) {
+            return next(errorHandler(403, 'Only administrators can delete content pages.'));
+        }
+
+        const page = await Page.findById(req.params.pageId);
+
+        if (!page) {
+            return next(errorHandler(404, 'Page not found.'));
+        }
+
+        await page.deleteOne();
+
+        res.status(200).json({ message: 'Page deleted successfully.' });
+    } catch (error) {
+        next(error);
+    }
+};
+
+export const getPublishedPageBySlug = async (req, res, next) => {
+    try {
+        const slugParam = req.params.slug?.toString().trim();
+
+        if (!slugParam) {
+            return next(errorHandler(400, 'A page slug is required.'));
+        }
+
+        const normalizedSlug = slugify(slugParam);
+        const page = await Page.findOne({ slug: normalizedSlug, status: 'published' }).lean();
+
+        if (!page) {
+            return next(errorHandler(404, 'Page not found.'));
+        }
+
+        page.sections = sortSections(page.sections ?? []);
+
+        res.status(200).json(page);
+    } catch (error) {
+        next(error);
+    }
+};

--- a/api/index.js
+++ b/api/index.js
@@ -11,6 +11,7 @@ import quizRoutes from './routes/quiz.route.js';
 import codeSnippetRoutes from './routes/codeSnippet.route.js';
 import cppRoutes from './routes/cpp.route.js';
 import pythonRoutes from './routes/python.route.js';
+import pageRoutes from './routes/page.route.js';
 
 import cookieParser from 'cookie-parser';
 import path from 'path';
@@ -61,6 +62,7 @@ app.use('/api/code-snippet', codeSnippetRoutes);
 app.use('/api', quizRoutes);
 app.use('/api/code', cppRoutes); // NEW: Use the new C++ route
 app.use('/api/code', pythonRoutes); // NEW: Use the new Python route
+app.use('/api', pageRoutes);
 
 app.use(express.static(path.join(__dirname, '/client/dist')));
 

--- a/api/models/page.model.js
+++ b/api/models/page.model.js
@@ -1,0 +1,72 @@
+import mongoose from 'mongoose';
+
+const pageItemSchema = new mongoose.Schema(
+    {
+        title: { type: String, trim: true },
+        body: { type: String, trim: true },
+        icon: { type: String, trim: true },
+    },
+    { _id: false }
+);
+
+const pageSectionSchema = new mongoose.Schema(
+    {
+        type: {
+            type: String,
+            enum: ['hero', 'rich-text', 'feature-grid', 'cta', 'custom'],
+            default: 'rich-text',
+        },
+        title: { type: String, trim: true },
+        subtitle: { type: String, trim: true },
+        body: { type: String, trim: true },
+        alignment: {
+            type: String,
+            enum: ['left', 'center', 'right'],
+            default: 'left',
+        },
+        background: { type: String, trim: true, default: 'default' },
+        media: {
+            url: { type: String, trim: true },
+            alt: { type: String, trim: true },
+        },
+        cta: {
+            label: { type: String, trim: true },
+            url: { type: String, trim: true },
+        },
+        items: [pageItemSchema],
+        order: { type: Number, default: 0 },
+    },
+    { timestamps: false }
+);
+
+const seoSchema = new mongoose.Schema(
+    {
+        metaTitle: { type: String, trim: true },
+        metaDescription: { type: String, trim: true },
+        keywords: { type: [String], default: [] },
+    },
+    { _id: false }
+);
+
+const pageSchema = new mongoose.Schema(
+    {
+        title: { type: String, required: true, trim: true },
+        slug: { type: String, required: true, unique: true, lowercase: true, trim: true },
+        description: { type: String, trim: true },
+        status: {
+            type: String,
+            enum: ['draft', 'published'],
+            default: 'draft',
+        },
+        publishedAt: { type: Date },
+        seo: { type: seoSchema, default: () => ({}) },
+        sections: { type: [pageSectionSchema], default: () => [] },
+        createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+        updatedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+    },
+    { timestamps: true }
+);
+
+const Page = mongoose.model('Page', pageSchema);
+
+export default Page;

--- a/api/routes/page.route.js
+++ b/api/routes/page.route.js
@@ -1,0 +1,22 @@
+import express from 'express';
+import {
+    createPage,
+    deletePage,
+    getPageById,
+    getPages,
+    getPublishedPageBySlug,
+    updatePage,
+} from '../controllers/page.controller.js';
+import { verifyToken } from '../utils/verifyUser.js';
+
+const router = express.Router();
+
+router.post('/pages', verifyToken, createPage);
+router.get('/pages', verifyToken, getPages);
+router.get('/pages/:pageId', verifyToken, getPageById);
+router.patch('/pages/:pageId', verifyToken, updatePage);
+router.delete('/pages/:pageId', verifyToken, deletePage);
+
+router.get('/content/:slug', getPublishedPageBySlug);
+
+export default router;

--- a/api/utils/slugify.js
+++ b/api/utils/slugify.js
@@ -1,0 +1,9 @@
+const slugify = (value = '') =>
+    value
+        .toString()
+        .toLowerCase()
+        .trim()
+        .replace(/[\s\W-]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+
+export default slugify;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -35,6 +35,9 @@ const UpdateQuiz = lazy(() => import('./pages/UpdateQuiz'));
 
 // NEW: Lazy load the Try it Yourself page
 const TryItPage = lazy(() => import('./pages/TryItPage'));
+const CreatePage = lazy(() => import('./pages/CreatePage'));
+const UpdatePage = lazy(() => import('./pages/UpdatePage'));
+const ContentPage = lazy(() => import('./pages/ContentPage'));
 
 // A fallback component to show while pages are loading
 const LoadingFallback = () => (
@@ -66,6 +69,7 @@ export default function App() {
 
                         {/* NEW: Try It Yourself Route */}
                         <Route path="tryit" element={<TryItPage />} />
+                        <Route path="content/:slug" element={<ContentPage />} />
 
                         {/* Private Routes also use the main layout */}
                         <Route element={<PrivateRoute />}>
@@ -82,6 +86,9 @@ export default function App() {
                             {/* Admin Quiz Routes */}
                             <Route path="create-quiz" element={<CreateQuiz />} />
                             <Route path="update-quiz/:quizId" element={<UpdateQuiz />} />
+                            {/* Admin Content Routes */}
+                            <Route path="create-page" element={<CreatePage />} />
+                            <Route path="update-page/:pageId" element={<UpdatePage />} />
                         </Route>
 
                         <Route path="*" element={<NotFound />} />

--- a/client/src/components/DashPages.jsx
+++ b/client/src/components/DashPages.jsx
@@ -1,0 +1,301 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+    Alert,
+    Badge,
+    Button,
+    Card,
+    Label,
+    Modal,
+    Select,
+    Spinner,
+    Table,
+    TextInput,
+} from 'flowbite-react';
+import {
+    HiOutlineExclamationCircle,
+    HiOutlineExternalLink,
+    HiOutlinePlus,
+    HiOutlineSearch,
+    HiPencilAlt,
+    HiTrash,
+} from 'react-icons/hi';
+import { deletePage, getPages } from '../services/pageService.js';
+
+const formatDate = (value) => {
+    if (!value) {
+        return '—';
+    }
+
+    try {
+        return new Date(value).toLocaleDateString();
+    } catch (error) {
+        return value;
+    }
+};
+
+const statusColor = (status) => (status === 'published' ? 'success' : 'warning');
+
+const DashPages = () => {
+    const { currentUser } = useSelector((state) => state.user);
+    const queryClient = useQueryClient();
+
+    const [searchTerm, setSearchTerm] = useState('');
+    const [debouncedSearch, setDebouncedSearch] = useState('');
+    const [statusFilter, setStatusFilter] = useState('all');
+    const [showModal, setShowModal] = useState(false);
+    const [pageToDelete, setPageToDelete] = useState(null);
+
+    useEffect(() => {
+        const timeout = setTimeout(() => {
+            setDebouncedSearch(searchTerm.trim());
+        }, 400);
+
+        return () => clearTimeout(timeout);
+    }, [searchTerm]);
+
+    const filters = useMemo(
+        () => ({
+            status: statusFilter,
+            search: debouncedSearch,
+            limit: 8,
+        }),
+        [statusFilter, debouncedSearch]
+    );
+
+    const {
+        data,
+        isLoading,
+        isError,
+        error,
+        fetchNextPage,
+        hasNextPage,
+        isFetchingNextPage,
+    } = useInfiniteQuery({
+        queryKey: ['adminPages', filters],
+        queryFn: ({ pageParam = 0, queryKey }) => getPages({ pageParam, queryKey }),
+        initialPageParam: 0,
+        getNextPageParam: (lastPage) => (lastPage?.hasMore ? lastPage.nextIndex : undefined),
+        enabled: Boolean(currentUser?.isAdmin),
+    });
+
+    const deleteMutation = useMutation({
+        mutationFn: deletePage,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['adminPages'] });
+        },
+    });
+
+    const pages = data?.pages.flatMap((page) => page.pages ?? []) ?? [];
+    const totalCount = data?.pages?.[0]?.totalCount ?? 0;
+    const lastMonthCount = data?.pages?.[0]?.lastMonthCount ?? 0;
+
+    const handleConfirmDelete = () => {
+        if (!pageToDelete) {
+            return;
+        }
+
+        deleteMutation.mutate(pageToDelete, {
+            onSuccess: () => {
+                setShowModal(false);
+                setPageToDelete(null);
+            },
+        });
+    };
+
+    if (!currentUser?.isAdmin) {
+        return (
+            <Card className='mx-auto mt-10 max-w-2xl text-center'>
+                <h2 className='text-xl font-semibold text-gray-900 dark:text-white'>Administrator access required</h2>
+                <p className='mt-2 text-sm text-gray-500 dark:text-gray-400'>
+                    You need administrator permissions to manage custom pages.
+                </p>
+            </Card>
+        );
+    }
+
+    return (
+        <div className='p-3 md:mx-auto'>
+            <div className='mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
+                <div>
+                    <h1 className='text-2xl font-semibold text-gray-900 dark:text-white'>Content management</h1>
+                    <p className='text-sm text-gray-500 dark:text-gray-400'>
+                        Build bespoke landing pages, curriculum outlines, and resource hubs without deploying code.
+                    </p>
+                </div>
+                <Button gradientDuoTone='purpleToBlue' as={Link} to='/create-page'>
+                    <HiOutlinePlus className='mr-2 h-5 w-5' /> New page
+                </Button>
+            </div>
+
+            <Card className='mb-5'>
+                <div className='flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between'>
+                    <div className='grid w-full gap-3 sm:grid-cols-2'>
+                        <div className='flex flex-col gap-2'>
+                            <Label htmlFor='page-search'>Search</Label>
+                            <TextInput
+                                id='page-search'
+                                icon={HiOutlineSearch}
+                                placeholder='Search by title or slug'
+                                value={searchTerm}
+                                onChange={(event) => setSearchTerm(event.target.value)}
+                            />
+                        </div>
+                        <div className='flex flex-col gap-2'>
+                            <Label htmlFor='status-filter'>Status</Label>
+                            <Select
+                                id='status-filter'
+                                value={statusFilter}
+                                onChange={(event) => setStatusFilter(event.target.value)}
+                            >
+                                <option value='all'>All pages</option>
+                                <option value='published'>Published</option>
+                                <option value='draft'>Draft</option>
+                            </Select>
+                        </div>
+                    </div>
+                    <div className='flex flex-col gap-1 text-sm text-gray-500 dark:text-gray-400'>
+                        <span>Total pages: {totalCount}</span>
+                        <span>Created in last 30 days: {lastMonthCount}</span>
+                    </div>
+                </div>
+            </Card>
+
+            {deleteMutation.isError && (
+                <Alert color='failure' onDismiss={() => deleteMutation.reset()} className='mb-5'>
+                    {deleteMutation.error?.response?.data?.message ||
+                        deleteMutation.error?.message ||
+                        'Failed to delete the selected page.'}
+                </Alert>
+            )}
+
+            {isLoading ? (
+                <div className='flex min-h-[40vh] items-center justify-center'>
+                    <Spinner size='xl' />
+                </div>
+            ) : isError ? (
+                <Alert color='failure'>
+                    {error?.response?.data?.message || error?.message || 'Failed to load content pages.'}
+                </Alert>
+            ) : pages.length === 0 ? (
+                <Card className='border border-dashed border-gray-200 p-10 text-center dark:border-gray-700'>
+                    <h2 className='text-lg font-semibold text-gray-900 dark:text-white'>No pages found</h2>
+                    <p className='mt-2 text-sm text-gray-500 dark:text-gray-400'>
+                        Start by creating a page to power a new learning journey or marketing campaign.
+                    </p>
+                    <Button className='mt-4' gradientDuoTone='purpleToBlue' as={Link} to='/create-page'>
+                        <HiOutlinePlus className='mr-2 h-5 w-5' /> Create your first page
+                    </Button>
+                </Card>
+            ) : (
+                <div className='space-y-4'>
+                    <div className='table-auto overflow-x-auto rounded-2xl border border-gray-100 shadow-sm dark:border-gray-700'>
+                        <Table hoverable>
+                            <Table.Head>
+                                <Table.HeadCell>Updated</Table.HeadCell>
+                                <Table.HeadCell>Title</Table.HeadCell>
+                                <Table.HeadCell>Slug</Table.HeadCell>
+                                <Table.HeadCell>Status</Table.HeadCell>
+                                <Table.HeadCell>Sections</Table.HeadCell>
+                                <Table.HeadCell className='w-36'>Actions</Table.HeadCell>
+                            </Table.Head>
+                            <Table.Body className='divide-y'>
+                                {pages.map((page) => (
+                                    <Table.Row key={page._id} className='bg-white dark:border-gray-700 dark:bg-gray-800'>
+                                        <Table.Cell>{formatDate(page.updatedAt)}</Table.Cell>
+                                        <Table.Cell className='max-w-xs'>
+                                            <div className='flex flex-col gap-1'>
+                                                <span className='font-medium text-gray-900 dark:text-white'>{page.title}</span>
+                                                {page.description && (
+                                                    <span className='text-xs text-gray-500 dark:text-gray-400 line-clamp-2'>
+                                                        {page.description}
+                                                    </span>
+                                                )}
+                                            </div>
+                                        </Table.Cell>
+                                        <Table.Cell>
+                                            <code className='text-xs text-gray-500 dark:text-gray-400'>/{page.slug}</code>
+                                        </Table.Cell>
+                                        <Table.Cell>
+                                            <Badge color={statusColor(page.status)}>{page.status}</Badge>
+                                        </Table.Cell>
+                                        <Table.Cell>{page.sections?.length ?? 0}</Table.Cell>
+                                        <Table.Cell>
+                                            <div className='flex items-center gap-2'>
+                                                <Button
+                                                    color='light'
+                                                    size='xs'
+                                                    pill
+                                                    as={Link}
+                                                    to={`/update-page/${page._id}`}
+                                                >
+                                                    <HiPencilAlt className='h-4 w-4' />
+                                                </Button>
+                                                <Button
+                                                    color='light'
+                                                    size='xs'
+                                                    pill
+                                                    as={Link}
+                                                    to={`/content/${page.slug}`}
+                                                >
+                                                    <HiOutlineExternalLink className='h-4 w-4' />
+                                                </Button>
+                                                <Button
+                                                    color='failure'
+                                                    size='xs'
+                                                    pill
+                                                    type='button'
+                                                    onClick={() => {
+                                                        setPageToDelete(page._id);
+                                                        setShowModal(true);
+                                                    }}
+                                                >
+                                                    <HiTrash className='h-4 w-4' />
+                                                </Button>
+                                            </div>
+                                        </Table.Cell>
+                                    </Table.Row>
+                                ))}
+                            </Table.Body>
+                        </Table>
+                    </div>
+                    {hasNextPage && (
+                        <div className='flex justify-center'>
+                            <Button
+                                color='light'
+                                onClick={() => fetchNextPage()}
+                                disabled={isFetchingNextPage}
+                            >
+                                {isFetchingNextPage ? 'Loading…' : 'Load more'}
+                            </Button>
+                        </div>
+                    )}
+                </div>
+            )}
+
+            <Modal show={showModal} size='md' popup onClose={() => setShowModal(false)}>
+                <Modal.Header />
+                <Modal.Body>
+                    <div className='text-center'>
+                        <HiOutlineExclamationCircle className='mx-auto mb-4 h-14 w-14 text-gray-400 dark:text-gray-200' />
+                        <h3 className='mb-5 text-lg text-gray-500 dark:text-gray-400'>
+                            Are you sure you want to delete this page?
+                        </h3>
+                        <div className='flex justify-center gap-4'>
+                            <Button color='failure' onClick={handleConfirmDelete} isProcessing={deleteMutation.isPending}>
+                                Yes, delete it
+                            </Button>
+                            <Button color='gray' onClick={() => setShowModal(false)} disabled={deleteMutation.isPending}>
+                                Cancel
+                            </Button>
+                        </div>
+                    </div>
+                </Modal.Body>
+            </Modal>
+        </div>
+    );
+};
+
+export default DashPages;

--- a/client/src/components/DashSidebar.jsx
+++ b/client/src/components/DashSidebar.jsx
@@ -8,6 +8,7 @@ import {
   HiAnnotation,
   HiChartPie,
   HiPuzzle, // NEW: Import puzzle icon for quizzes
+  HiCollection,
 } from 'react-icons/hi';
 import { useEffect, useState, useCallback } from 'react';
 import { Link, useLocation } from 'react-router-dom';
@@ -22,6 +23,7 @@ const sidebarLinks = [
   { tab: 'comments', label: 'Comments', icon: HiAnnotation, adminOnly: true },
   { tab: 'tutorials', label: 'Tutorials', icon: HiDocumentText, adminOnly: true },
   { tab: 'quizzes', label: 'Quizzes', icon: HiPuzzle, adminOnly: true }, // NEW: Add Quizzes link
+  { tab: 'content', label: 'Content', icon: HiCollection, adminOnly: true },
 ];
 
 export default function DashSidebar() {

--- a/client/src/components/PageForm.jsx
+++ b/client/src/components/PageForm.jsx
@@ -1,0 +1,764 @@
+import { useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Alert, Badge, Button, Card, Label, Select, Textarea, TextInput } from 'flowbite-react';
+import { HiArrowDown, HiArrowUp, HiPlus, HiTrash } from 'react-icons/hi';
+import PageRenderer from './PageRenderer.jsx';
+import slugify from '../utils/slugify.js';
+
+const uniqueId = () => (typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2, 10));
+
+const createSection = (type = 'rich-text') => {
+    const base = {
+        id: uniqueId(),
+        type,
+        title: '',
+        subtitle: '',
+        body: '',
+        alignment: 'left',
+        background: 'default',
+        mediaUrl: '',
+        mediaAlt: '',
+        ctaLabel: '',
+        ctaUrl: '',
+        items: [],
+    };
+
+    if (type === 'hero') {
+        base.alignment = 'left';
+        base.background = 'panel';
+    }
+
+    if (type === 'cta') {
+        base.alignment = 'center';
+        base.background = 'accent';
+    }
+
+    return base;
+};
+
+const transformInitialValues = (values) => {
+    if (!values) {
+        return {
+            title: '',
+            slug: '',
+            description: '',
+            status: 'draft',
+            seo: { metaTitle: '', metaDescription: '' },
+            sections: [createSection('hero')],
+        };
+    }
+
+    const sections = Array.isArray(values.sections) && values.sections.length > 0
+        ? values.sections
+        : [createSection('rich-text')];
+
+    return {
+        title: values.title ?? '',
+        slug: values.slug ?? '',
+        description: values.description ?? '',
+        status: values.status ?? 'draft',
+        seo: {
+            metaTitle: values.seo?.metaTitle ?? '',
+            metaDescription: values.seo?.metaDescription ?? '',
+        },
+        sections: sections.map((section) => ({
+            id: uniqueId(),
+            type: section.type ?? 'rich-text',
+            title: section.title ?? '',
+            subtitle: section.subtitle ?? '',
+            body: section.body ?? '',
+            alignment: section.alignment ?? (section.type === 'cta' ? 'center' : 'left'),
+            background: section.background ?? 'default',
+            mediaUrl: section.media?.url ?? '',
+            mediaAlt: section.media?.alt ?? '',
+            ctaLabel: section.cta?.label ?? '',
+            ctaUrl: section.cta?.url ?? '',
+            items: Array.isArray(section.items)
+                ? section.items.map((item) => ({
+                      id: uniqueId(),
+                      title: item.title ?? '',
+                      body: item.body ?? '',
+                      icon: item.icon ?? '',
+                  }))
+                : [],
+        })),
+    };
+};
+
+const sanitizeForm = (formState, keywordsInput) => {
+    const safeString = (value = '') => value.toString().trim();
+
+    const title = safeString(formState.title);
+    const slug = safeString(formState.slug) || slugify(title);
+    const description = safeString(formState.description);
+
+    const keywords = keywordsInput
+        .split(',')
+        .map((keyword) => keyword.trim())
+        .filter(Boolean);
+
+    const sections = formState.sections
+        .map((section, index) => {
+            const titleValue = safeString(section.title);
+            const subtitleValue = safeString(section.subtitle);
+            const bodyValue = safeString(section.body);
+            const mediaUrl = safeString(section.mediaUrl);
+            const mediaAlt = safeString(section.mediaAlt);
+            const ctaLabel = safeString(section.ctaLabel);
+            const ctaUrl = safeString(section.ctaUrl);
+
+            const items = Array.isArray(section.items)
+                ? section.items
+                      .map((item) => ({
+                          title: safeString(item.title),
+                          body: safeString(item.body),
+                          icon: safeString(item.icon),
+                      }))
+                      .filter((item) => item.title || item.body || item.icon)
+                : [];
+
+            const hasContent =
+                titleValue || subtitleValue || bodyValue || items.length > 0 || mediaUrl || ctaLabel || ctaUrl;
+
+            if (!hasContent) {
+                return null;
+            }
+
+            const sanitizedSection = {
+                type: section.type,
+                title: titleValue,
+                subtitle: subtitleValue,
+                body: bodyValue,
+                alignment: section.alignment,
+                background: section.background,
+                order: index,
+            };
+
+            if (items.length > 0) {
+                sanitizedSection.items = items;
+            }
+
+            if (mediaUrl || mediaAlt) {
+                sanitizedSection.media = {
+                    url: mediaUrl,
+                    alt: mediaAlt,
+                };
+            }
+
+            if (ctaLabel || ctaUrl) {
+                sanitizedSection.cta = {
+                    label: ctaLabel,
+                    url: ctaUrl,
+                };
+            }
+
+            return sanitizedSection;
+        })
+        .filter(Boolean);
+
+    return {
+        title,
+        slug,
+        description,
+        status: formState.status === 'published' ? 'published' : 'draft',
+        seo: {
+            metaTitle: safeString(formState.seo?.metaTitle) || title,
+            metaDescription: safeString(formState.seo?.metaDescription) || description,
+            keywords,
+        },
+        sections,
+    };
+};
+
+const PageForm = ({ initialValues, onSubmit, isSubmitting = false, submitLabel = 'Save page', errorMessage }) => {
+    const [formState, setFormState] = useState(() => transformInitialValues(initialValues));
+    const [keywordsInput, setKeywordsInput] = useState(() => (initialValues?.seo?.keywords ?? []).join(', '));
+    const [slugEdited, setSlugEdited] = useState(Boolean(initialValues?.slug));
+    const [localError, setLocalError] = useState(null);
+
+    useEffect(() => {
+        if (initialValues) {
+            setFormState(transformInitialValues(initialValues));
+            setKeywordsInput((initialValues.seo?.keywords ?? []).join(', '));
+            setSlugEdited(Boolean(initialValues.slug));
+        }
+    }, [initialValues]);
+
+    const previewPayload = useMemo(() => sanitizeForm(formState, keywordsInput), [formState, keywordsInput]);
+
+    const handleTitleChange = (value) => {
+        setFormState((prev) => {
+            const next = {
+                ...prev,
+                title: value,
+                seo: {
+                    ...prev.seo,
+                    metaTitle: prev.seo?.metaTitle || value,
+                },
+            };
+
+            if (!slugEdited) {
+                next.slug = slugify(value);
+            }
+
+            return next;
+        });
+    };
+
+    const handleSlugChange = (value) => {
+        setSlugEdited(true);
+        setFormState((prev) => ({ ...prev, slug: value }));
+    };
+
+    const handleSeoChange = (field, value) => {
+        setFormState((prev) => ({
+            ...prev,
+            seo: {
+                ...prev.seo,
+                [field]: value,
+            },
+        }));
+    };
+
+    const handleSectionChange = (sectionId, field, value) => {
+        setFormState((prev) => ({
+            ...prev,
+            sections: prev.sections.map((section) => {
+                if (section.id !== sectionId) {
+                    return section;
+                }
+
+                const updated = { ...section, [field]: value };
+
+                if (field === 'type') {
+                    updated.type = value;
+
+                    if (value === 'hero') {
+                        updated.alignment = 'left';
+                        updated.background = 'panel';
+                    } else if (value === 'cta') {
+                        updated.alignment = 'center';
+                        updated.background = 'accent';
+                    }
+
+                    if (value !== 'feature-grid') {
+                        updated.items = [];
+                    }
+                }
+
+                return updated;
+            }),
+        }));
+    };
+
+    const handleMoveSection = (sectionId, direction) => {
+        setFormState((prev) => {
+            const index = prev.sections.findIndex((section) => section.id === sectionId);
+            if (index === -1) {
+                return prev;
+            }
+
+            const targetIndex = direction === 'up' ? index - 1 : index + 1;
+
+            if (targetIndex < 0 || targetIndex >= prev.sections.length) {
+                return prev;
+            }
+
+            const updatedSections = [...prev.sections];
+            const [section] = updatedSections.splice(index, 1);
+            updatedSections.splice(targetIndex, 0, section);
+
+            return { ...prev, sections: updatedSections };
+        });
+    };
+
+    const handleRemoveSection = (sectionId) => {
+        setFormState((prev) => ({
+            ...prev,
+            sections: prev.sections.filter((section) => section.id !== sectionId),
+        }));
+    };
+
+    const handleAddSection = (type = 'rich-text') => {
+        setFormState((prev) => ({
+            ...prev,
+            sections: [...prev.sections, createSection(type)],
+        }));
+    };
+
+    const handleItemChange = (sectionId, itemId, field, value) => {
+        setFormState((prev) => ({
+            ...prev,
+            sections: prev.sections.map((section) => {
+                if (section.id !== sectionId) {
+                    return section;
+                }
+
+                const items = section.items.map((item) =>
+                    item.id === itemId ? { ...item, [field]: value } : item
+                );
+
+                return { ...section, items };
+            }),
+        }));
+    };
+
+    const handleAddItem = (sectionId) => {
+        setFormState((prev) => ({
+            ...prev,
+            sections: prev.sections.map((section) => {
+                if (section.id !== sectionId) {
+                    return section;
+                }
+
+                return {
+                    ...section,
+                    items: [
+                        ...section.items,
+                        {
+                            id: uniqueId(),
+                            title: '',
+                            body: '',
+                            icon: '',
+                        },
+                    ],
+                };
+            }),
+        }));
+    };
+
+    const handleRemoveItem = (sectionId, itemId) => {
+        setFormState((prev) => ({
+            ...prev,
+            sections: prev.sections.map((section) => {
+                if (section.id !== sectionId) {
+                    return section;
+                }
+
+                return {
+                    ...section,
+                    items: section.items.filter((item) => item.id !== itemId),
+                };
+            }),
+        }));
+    };
+
+    const handleSubmit = async (event) => {
+        event.preventDefault();
+        setLocalError(null);
+
+        const sanitizedTitle = formState.title?.toString().trim();
+
+        if (!sanitizedTitle) {
+            setLocalError('A title is required before publishing a page.');
+            return;
+        }
+
+        const payload = sanitizeForm(formState, keywordsInput);
+
+        if (payload.sections.length === 0) {
+            setLocalError('Add at least one section with content to build the page.');
+            return;
+        }
+
+        try {
+            await onSubmit(payload);
+        } catch (error) {
+            const message = error?.response?.data?.message || error?.message || 'Failed to save the page.';
+            setLocalError(message);
+        }
+    };
+
+    const statusBadgeColor = formState.status === 'published' ? 'success' : 'warning';
+
+    return (
+        <form onSubmit={handleSubmit} className='space-y-6'>
+            {(localError || errorMessage) && (
+                <Alert color='failure'>
+                    {localError || errorMessage}
+                </Alert>
+            )}
+
+            <div className='grid gap-6 lg:grid-cols-[minmax(0,2fr),minmax(0,1fr)]'>
+                <div className='space-y-6'>
+                    <Card className='space-y-5'>
+                        <div className='flex flex-col gap-4'>
+                            <div className='grid gap-4 md:grid-cols-2'>
+                                <div className='flex flex-col gap-2'>
+                                    <Label htmlFor='title'>Title</Label>
+                                    <TextInput
+                                        id='title'
+                                        placeholder='Page title'
+                                        value={formState.title}
+                                        onChange={(event) => handleTitleChange(event.target.value)}
+                                        required
+                                    />
+                                </div>
+                                <div className='flex flex-col gap-2'>
+                                    <Label htmlFor='slug'>Slug</Label>
+                                    <TextInput
+                                        id='slug'
+                                        placeholder='my-custom-page'
+                                        value={formState.slug}
+                                        onChange={(event) => handleSlugChange(slugify(event.target.value))}
+                                        helperText='This determines the public URL of the page.'
+                                    />
+                                </div>
+                            </div>
+
+                            <div className='flex flex-col gap-2'>
+                                <Label htmlFor='description'>Summary</Label>
+                                <Textarea
+                                    id='description'
+                                    rows={3}
+                                    placeholder='Short description used in previews and SEO metadata.'
+                                    value={formState.description}
+                                    onChange={(event) => setFormState((prev) => ({ ...prev, description: event.target.value }))}
+                                />
+                            </div>
+
+                            <div className='grid gap-4 md:grid-cols-2'>
+                                <div className='flex flex-col gap-2'>
+                                    <Label htmlFor='status'>Status</Label>
+                                    <Select
+                                        id='status'
+                                        value={formState.status}
+                                        onChange={(event) => setFormState((prev) => ({ ...prev, status: event.target.value }))}
+                                    >
+                                        <option value='draft'>Draft</option>
+                                        <option value='published'>Published</option>
+                                    </Select>
+                                </div>
+                                <div className='flex flex-col gap-2'>
+                                    <Label htmlFor='keywords'>Keywords</Label>
+                                    <TextInput
+                                        id='keywords'
+                                        placeholder='science, engineering, tutorials'
+                                        value={keywordsInput}
+                                        onChange={(event) => setKeywordsInput(event.target.value)}
+                                        helperText='Separate keywords with commas for SEO.'
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    </Card>
+
+                    <Card className='space-y-4'>
+                        <div className='grid gap-4 md:grid-cols-2'>
+                            <div className='flex flex-col gap-2'>
+                                <Label htmlFor='metaTitle'>SEO title</Label>
+                                <TextInput
+                                    id='metaTitle'
+                                    placeholder='Custom meta title (optional)'
+                                    value={formState.seo?.metaTitle ?? ''}
+                                    onChange={(event) => handleSeoChange('metaTitle', event.target.value)}
+                                />
+                            </div>
+                            <div className='flex flex-col gap-2'>
+                                <Label htmlFor='metaDescription'>SEO description</Label>
+                                <Textarea
+                                    id='metaDescription'
+                                    rows={2}
+                                    placeholder='Custom meta description (optional)'
+                                    value={formState.seo?.metaDescription ?? ''}
+                                    onChange={(event) => handleSeoChange('metaDescription', event.target.value)}
+                                />
+                            </div>
+                        </div>
+                    </Card>
+
+                    <div className='flex items-center justify-between'>
+                        <h2 className='text-xl font-semibold text-gray-900 dark:text-white'>Page sections</h2>
+                        <div className='flex gap-2'>
+                            <Button color='light' size='sm' onClick={() => handleAddSection('hero')} type='button'>
+                                <HiPlus className='mr-1 h-4 w-4' /> Hero
+                            </Button>
+                            <Button color='light' size='sm' onClick={() => handleAddSection('feature-grid')} type='button'>
+                                <HiPlus className='mr-1 h-4 w-4' /> Feature grid
+                            </Button>
+                            <Button color='light' size='sm' onClick={() => handleAddSection('cta')} type='button'>
+                                <HiPlus className='mr-1 h-4 w-4' /> CTA
+                            </Button>
+                            <Button color='light' size='sm' onClick={() => handleAddSection('rich-text')} type='button'>
+                                <HiPlus className='mr-1 h-4 w-4' /> Text
+                            </Button>
+                        </div>
+                    </div>
+
+                    <div className='space-y-5'>
+                        {formState.sections.map((section, index) => (
+                            <Card key={section.id} className='space-y-5 border border-gray-200/80 dark:border-gray-700/70'>
+                                <div className='flex flex-wrap items-center justify-between gap-3'>
+                                    <div className='flex items-center gap-3'>
+                                        <Badge color='indigo'>Section {index + 1}</Badge>
+                                        <span className='text-sm uppercase tracking-wide text-gray-500 dark:text-gray-400'>
+                                            {section.type}
+                                        </span>
+                                    </div>
+                                    <div className='flex items-center gap-2'>
+                                        <Button
+                                            color='light'
+                                            pill
+                                            size='xs'
+                                            type='button'
+                                            onClick={() => handleMoveSection(section.id, 'up')}
+                                            disabled={index === 0}
+                                        >
+                                            <HiArrowUp className='h-4 w-4' />
+                                        </Button>
+                                        <Button
+                                            color='light'
+                                            pill
+                                            size='xs'
+                                            type='button'
+                                            onClick={() => handleMoveSection(section.id, 'down')}
+                                            disabled={index === formState.sections.length - 1}
+                                        >
+                                            <HiArrowDown className='h-4 w-4' />
+                                        </Button>
+                                        <Button
+                                            color='failure'
+                                            pill
+                                            size='xs'
+                                            type='button'
+                                            onClick={() => handleRemoveSection(section.id)}
+                                        >
+                                            <HiTrash className='h-4 w-4' />
+                                        </Button>
+                                    </div>
+                                </div>
+
+                                <div className='grid gap-4 md:grid-cols-2'>
+                                    <div className='flex flex-col gap-2'>
+                                        <Label>Section type</Label>
+                                        <Select
+                                            value={section.type}
+                                            onChange={(event) => handleSectionChange(section.id, 'type', event.target.value)}
+                                        >
+                                            <option value='hero'>Hero</option>
+                                            <option value='rich-text'>Rich text</option>
+                                            <option value='feature-grid'>Feature grid</option>
+                                            <option value='cta'>Call to action</option>
+                                            <option value='custom'>Custom</option>
+                                        </Select>
+                                    </div>
+                                    <div className='flex flex-col gap-2'>
+                                        <Label>Alignment</Label>
+                                        <Select
+                                            value={section.alignment}
+                                            onChange={(event) => handleSectionChange(section.id, 'alignment', event.target.value)}
+                                        >
+                                            <option value='left'>Left</option>
+                                            <option value='center'>Center</option>
+                                            <option value='right'>Right</option>
+                                        </Select>
+                                    </div>
+                                </div>
+
+                                <div className='grid gap-4 md:grid-cols-2'>
+                                    <div className='flex flex-col gap-2'>
+                                        <Label>Background style</Label>
+                                        <Select
+                                            value={section.background}
+                                            onChange={(event) => handleSectionChange(section.id, 'background', event.target.value)}
+                                        >
+                                            <option value='default'>Default</option>
+                                            <option value='muted'>Muted</option>
+                                            <option value='accent'>Accent</option>
+                                            <option value='panel'>Panel</option>
+                                        </Select>
+                                    </div>
+                                    <div className='flex flex-col gap-2'>
+                                        <Label>Section title</Label>
+                                        <TextInput
+                                            value={section.title}
+                                            placeholder='Introduce the section'
+                                            onChange={(event) => handleSectionChange(section.id, 'title', event.target.value)}
+                                        />
+                                    </div>
+                                </div>
+
+                                <div className='grid gap-4 md:grid-cols-2'>
+                                    <div className='flex flex-col gap-2'>
+                                        <Label>Section subtitle</Label>
+                                        <TextInput
+                                            value={section.subtitle}
+                                            placeholder='Optional subtitle'
+                                            onChange={(event) => handleSectionChange(section.id, 'subtitle', event.target.value)}
+                                        />
+                                    </div>
+                                    <div className='flex flex-col gap-2'>
+                                        <Label>Body content</Label>
+                                        <Textarea
+                                            rows={section.type === 'hero' ? 4 : 3}
+                                            value={section.body}
+                                            placeholder='Write the content for this section'
+                                            onChange={(event) => handleSectionChange(section.id, 'body', event.target.value)}
+                                        />
+                                    </div>
+                                </div>
+
+                                <div className='grid gap-4 md:grid-cols-2'>
+                                    <div className='flex flex-col gap-2'>
+                                        <Label>Media URL</Label>
+                                        <TextInput
+                                            value={section.mediaUrl}
+                                            placeholder='https://example.com/image.png'
+                                            onChange={(event) => handleSectionChange(section.id, 'mediaUrl', event.target.value)}
+                                        />
+                                    </div>
+                                    <div className='flex flex-col gap-2'>
+                                        <Label>Media alt text</Label>
+                                        <TextInput
+                                            value={section.mediaAlt}
+                                            placeholder='Describe the media for accessibility'
+                                            onChange={(event) => handleSectionChange(section.id, 'mediaAlt', event.target.value)}
+                                        />
+                                    </div>
+                                </div>
+
+                                <div className='grid gap-4 md:grid-cols-2'>
+                                    <div className='flex flex-col gap-2'>
+                                        <Label>CTA label</Label>
+                                        <TextInput
+                                            value={section.ctaLabel}
+                                            placeholder='Call to action label'
+                                            onChange={(event) => handleSectionChange(section.id, 'ctaLabel', event.target.value)}
+                                        />
+                                    </div>
+                                    <div className='flex flex-col gap-2'>
+                                        <Label>CTA URL</Label>
+                                        <TextInput
+                                            value={section.ctaUrl}
+                                            placeholder='https://example.com/signup'
+                                            onChange={(event) => handleSectionChange(section.id, 'ctaUrl', event.target.value)}
+                                        />
+                                    </div>
+                                </div>
+
+                                {section.type === 'feature-grid' && (
+                                    <div className='space-y-4'>
+                                        <div className='flex items-center justify-between'>
+                                            <h3 className='text-lg font-semibold text-gray-900 dark:text-white'>Feature items</h3>
+                                            <Button size='xs' color='light' type='button' onClick={() => handleAddItem(section.id)}>
+                                                <HiPlus className='mr-1 h-4 w-4' /> Add item
+                                            </Button>
+                                        </div>
+                                        <div className='space-y-4'>
+                                            {section.items.map((item) => (
+                                                <Card key={item.id} className='border border-gray-200/80 p-4 dark:border-gray-700/70'>
+                                                    <div className='grid gap-4 md:grid-cols-2'>
+                                                        <div className='flex flex-col gap-2'>
+                                                            <Label>Item title</Label>
+                                                            <TextInput
+                                                                value={item.title}
+                                                                placeholder='Feature title'
+                                                                onChange={(event) =>
+                                                                    handleItemChange(section.id, item.id, 'title', event.target.value)
+                                                                }
+                                                            />
+                                                        </div>
+                                                        <div className='flex flex-col gap-2'>
+                                                            <Label>Icon (emoji or short text)</Label>
+                                                            <TextInput
+                                                                value={item.icon}
+                                                                placeholder='🚀'
+                                                                onChange={(event) =>
+                                                                    handleItemChange(section.id, item.id, 'icon', event.target.value)
+                                                                }
+                                                            />
+                                                        </div>
+                                                    </div>
+                                                    <div className='mt-3 flex flex-col gap-2'>
+                                                        <Label>Item description</Label>
+                                                        <Textarea
+                                                            rows={3}
+                                                            value={item.body}
+                                                            placeholder='Explain what makes this feature special.'
+                                                            onChange={(event) =>
+                                                                handleItemChange(section.id, item.id, 'body', event.target.value)
+                                                            }
+                                                        />
+                                                    </div>
+                                                    <div className='mt-3 flex justify-end'>
+                                                        <Button
+                                                            color='failure'
+                                                            size='xs'
+                                                            type='button'
+                                                            onClick={() => handleRemoveItem(section.id, item.id)}
+                                                        >
+                                                            <HiTrash className='mr-1 h-4 w-4' /> Remove item
+                                                        </Button>
+                                                    </div>
+                                                </Card>
+                                            ))}
+                                            {section.items.length === 0 && (
+                                                <p className='text-sm text-gray-500 dark:text-gray-400'>
+                                                    Add cards to highlight individual features or resources.
+                                                </p>
+                                            )}
+                                        </div>
+                                    </div>
+                                )}
+                            </Card>
+                        ))}
+
+                        {formState.sections.length === 0 && (
+                            <Card className='border border-dashed border-gray-300 p-6 text-center dark:border-gray-700'>
+                                <p className='text-sm text-gray-500 dark:text-gray-400'>
+                                    You have no sections yet. Use the buttons above to add content blocks.
+                                </p>
+                            </Card>
+                        )}
+                    </div>
+                </div>
+
+                <div className='space-y-4 lg:sticky lg:top-24'>
+                    <Card className='space-y-4'>
+                        <div className='flex items-center justify-between'>
+                            <h3 className='text-lg font-semibold text-gray-900 dark:text-white'>Summary</h3>
+                            <Badge color={statusBadgeColor}>{formState.status}</Badge>
+                        </div>
+                        <div className='text-sm text-gray-500 dark:text-gray-400'>/{previewPayload.slug}</div>
+                        <div className='text-sm text-gray-500 dark:text-gray-400'>
+                            {previewPayload.seo.keywords.length > 0 ? (
+                                <span>Keywords: {previewPayload.seo.keywords.join(', ')}</span>
+                            ) : (
+                                <span>No keywords added yet.</span>
+                            )}
+                        </div>
+                        <Button type='submit' gradientDuoTone='purpleToPink' isProcessing={isSubmitting} disabled={isSubmitting}>
+                            {submitLabel}
+                        </Button>
+                    </Card>
+
+                    <Card className='max-h-[75vh] overflow-y-auto pr-2'>
+                        <h3 className='mb-4 text-lg font-semibold text-gray-900 dark:text-white'>Live preview</h3>
+                        <PageRenderer page={previewPayload} compact />
+                    </Card>
+                </div>
+            </div>
+        </form>
+    );
+};
+
+PageForm.propTypes = {
+    initialValues: PropTypes.shape({
+        title: PropTypes.string,
+        slug: PropTypes.string,
+        description: PropTypes.string,
+        status: PropTypes.string,
+        seo: PropTypes.shape({
+            metaTitle: PropTypes.string,
+            metaDescription: PropTypes.string,
+            keywords: PropTypes.arrayOf(PropTypes.string),
+        }),
+        sections: PropTypes.arrayOf(PropTypes.object),
+    }),
+    onSubmit: PropTypes.func.isRequired,
+    isSubmitting: PropTypes.bool,
+    submitLabel: PropTypes.string,
+    errorMessage: PropTypes.string,
+};
+
+export default PageForm;

--- a/client/src/components/PageRenderer.jsx
+++ b/client/src/components/PageRenderer.jsx
@@ -1,0 +1,296 @@
+import PropTypes from 'prop-types';
+import { Badge, Button, Card } from 'flowbite-react';
+
+const getBackgroundClass = (background) => {
+    switch (background) {
+        case 'muted':
+            return 'bg-gray-50 dark:bg-gray-800/70';
+        case 'accent':
+            return 'bg-gradient-to-r from-teal-500/10 via-blue-500/10 to-purple-500/10';
+        case 'panel':
+            return 'bg-white/80 dark:bg-gray-900/70 shadow-sm ring-1 ring-gray-100/60 dark:ring-gray-800/80 backdrop-blur';
+        default:
+            return '';
+    }
+};
+
+const alignmentClass = (alignment) => {
+    switch (alignment) {
+        case 'center':
+            return 'text-center items-center';
+        case 'right':
+            return 'text-right items-end';
+        default:
+            return 'text-left items-start';
+    }
+};
+
+const Paragraphs = ({ text }) => {
+    if (!text) {
+        return null;
+    }
+
+    return text
+        .split(/\n+/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((line, index) => (
+            <p key={index} className='text-base leading-relaxed text-gray-600 dark:text-gray-300'>
+                {line}
+            </p>
+        ));
+};
+
+Paragraphs.propTypes = {
+    text: PropTypes.string,
+};
+
+const HeroSection = ({ section }) => (
+    <div
+        className={`relative overflow-hidden rounded-3xl border border-gray-100/60 dark:border-gray-800 ${getBackgroundClass(
+            section.background
+        )}`}
+    >
+        <div className='absolute inset-0 bg-gradient-to-br from-white/60 via-transparent to-transparent dark:from-gray-900/80' />
+        <div className='relative grid gap-10 p-10 md:grid-cols-2 md:items-center'>
+            <div className='flex flex-col gap-4'>
+                <Badge color='indigo' className='w-fit text-sm uppercase tracking-wide opacity-80'>
+                    {section.subtitle || 'Featured'}
+                </Badge>
+                <h2 className='text-4xl font-bold text-gray-900 dark:text-white md:text-5xl'>{section.title}</h2>
+                <Paragraphs text={section.body} />
+                {section.cta?.label && (
+                    <div className='mt-4'>
+                        <Button color='purple' href={section.cta.url || '#'} as='a'>
+                            {section.cta.label}
+                        </Button>
+                    </div>
+                )}
+            </div>
+            {section.media?.url && (
+                <div className='relative isolate'>
+                    <div className='absolute -inset-6 rounded-3xl bg-purple-500/20 blur-3xl dark:bg-purple-500/10' />
+                    <img
+                        src={section.media.url}
+                        alt={section.media.alt || section.title}
+                        className='relative z-10 w-full rounded-2xl object-cover shadow-xl'
+                    />
+                </div>
+            )}
+        </div>
+    </div>
+);
+
+HeroSection.propTypes = {
+    section: PropTypes.shape({
+        title: PropTypes.string,
+        subtitle: PropTypes.string,
+        body: PropTypes.string,
+        cta: PropTypes.shape({
+            label: PropTypes.string,
+            url: PropTypes.string,
+        }),
+        media: PropTypes.shape({
+            url: PropTypes.string,
+            alt: PropTypes.string,
+        }),
+        background: PropTypes.string,
+    }).isRequired,
+};
+
+const FeatureGridSection = ({ section }) => (
+    <div className={`rounded-3xl border border-gray-100/60 p-6 dark:border-gray-800 ${getBackgroundClass(section.background)}`}>
+        <div className={`flex flex-col gap-4 ${alignmentClass(section.alignment)}`}>
+            <div>
+                {section.subtitle && (
+                    <span className='text-sm font-semibold uppercase tracking-wide text-indigo-500'>{section.subtitle}</span>
+                )}
+                <h3 className='text-3xl font-semibold text-gray-900 dark:text-white'>{section.title}</h3>
+            </div>
+            <Paragraphs text={section.body} />
+            <div className='grid gap-6 md:grid-cols-2'>
+                {section.items?.map((item, index) => (
+                    <Card key={index} className='h-full border-none shadow-none ring-1 ring-gray-100 dark:ring-gray-800'>
+                        <div className='flex flex-col gap-2'>
+                            {item.icon && (
+                                <span className='text-3xl text-indigo-500' aria-hidden>
+                                    {item.icon}
+                                </span>
+                            )}
+                            <h4 className='text-xl font-semibold text-gray-900 dark:text-white'>{item.title}</h4>
+                            <p className='text-sm text-gray-600 dark:text-gray-300'>{item.body}</p>
+                        </div>
+                    </Card>
+                ))}
+            </div>
+        </div>
+    </div>
+);
+
+FeatureGridSection.propTypes = {
+    section: PropTypes.shape({
+        title: PropTypes.string,
+        subtitle: PropTypes.string,
+        body: PropTypes.string,
+        alignment: PropTypes.oneOf(['left', 'center', 'right']),
+        background: PropTypes.string,
+        items: PropTypes.arrayOf(
+            PropTypes.shape({
+                title: PropTypes.string,
+                body: PropTypes.string,
+                icon: PropTypes.string,
+            })
+        ),
+    }).isRequired,
+};
+
+const CTASection = ({ section }) => (
+    <div
+        className={`relative overflow-hidden rounded-3xl border border-gray-100/60 p-10 text-center shadow-sm dark:border-gray-800 ${getBackgroundClass(
+            section.background
+        )}`}
+    >
+        <div className='mx-auto flex max-w-2xl flex-col items-center gap-4'>
+            {section.subtitle && <Badge color='purple'>{section.subtitle}</Badge>}
+            <h3 className='text-3xl font-semibold text-gray-900 dark:text-white'>{section.title}</h3>
+            <Paragraphs text={section.body} />
+            {section.cta?.label && (
+                <Button color='purple' size='lg' href={section.cta.url || '#'} as='a'>
+                    {section.cta.label}
+                </Button>
+            )}
+        </div>
+    </div>
+);
+
+CTASection.propTypes = {
+    section: PropTypes.shape({
+        title: PropTypes.string,
+        subtitle: PropTypes.string,
+        body: PropTypes.string,
+        cta: PropTypes.shape({
+            label: PropTypes.string,
+            url: PropTypes.string,
+        }),
+        background: PropTypes.string,
+    }).isRequired,
+};
+
+const RichTextSection = ({ section }) => (
+    <div className={`rounded-3xl border border-gray-100/60 p-8 dark:border-gray-800 ${getBackgroundClass(section.background)}`}>
+        <div className={`flex flex-col gap-4 ${alignmentClass(section.alignment)}`}>
+            <div>
+                {section.subtitle && (
+                    <span className='text-sm font-semibold uppercase tracking-wide text-indigo-500'>{section.subtitle}</span>
+                )}
+                <h3 className='text-3xl font-semibold text-gray-900 dark:text-white'>{section.title}</h3>
+            </div>
+            <Paragraphs text={section.body} />
+            {section.media?.url && (
+                <img
+                    src={section.media.url}
+                    alt={section.media.alt || section.title}
+                    className='mt-4 w-full rounded-2xl object-cover shadow'
+                />
+            )}
+            {section.cta?.label && (
+                <div className='mt-2'>
+                    <Button color='light' href={section.cta.url || '#'} as='a'>
+                        {section.cta.label}
+                    </Button>
+                </div>
+            )}
+        </div>
+    </div>
+);
+
+RichTextSection.propTypes = {
+    section: PropTypes.shape({
+        title: PropTypes.string,
+        subtitle: PropTypes.string,
+        body: PropTypes.string,
+        alignment: PropTypes.oneOf(['left', 'center', 'right']),
+        background: PropTypes.string,
+        media: PropTypes.shape({
+            url: PropTypes.string,
+            alt: PropTypes.string,
+        }),
+        cta: PropTypes.shape({
+            label: PropTypes.string,
+            url: PropTypes.string,
+        }),
+    }).isRequired,
+};
+
+const renderSection = (section) => {
+    switch (section.type) {
+        case 'hero':
+            return <HeroSection section={section} />;
+        case 'feature-grid':
+            return <FeatureGridSection section={section} />;
+        case 'cta':
+            return <CTASection section={section} />;
+        default:
+            return <RichTextSection section={section} />;
+    }
+};
+
+const PageRenderer = ({ page, compact = false }) => {
+    if (!page) {
+        return null;
+    }
+
+    const sections = [...(page.sections ?? [])].sort((a, b) => (Number(a.order) || 0) - (Number(b.order) || 0));
+
+    const containerClasses = compact
+        ? 'mx-auto flex max-w-4xl flex-col gap-6'
+        : 'mx-auto flex min-h-screen max-w-5xl flex-col gap-10 px-4 py-10 sm:px-6 lg:px-8';
+
+    const headerClasses = compact
+        ? 'flex flex-col gap-3 text-left'
+        : 'mx-auto flex max-w-3xl flex-col items-center gap-4 text-center';
+
+    return (
+        <div className={containerClasses}>
+            <header className={headerClasses}>
+                <h1
+                    className={`font-bold tracking-tight text-gray-900 dark:text-white ${
+                        compact ? 'text-3xl md:text-4xl' : 'text-4xl md:text-5xl'
+                    }`}
+                >
+                    {page.title}
+                </h1>
+                {page.description && (
+                    <p className={`text-gray-600 dark:text-gray-300 ${compact ? 'text-base md:text-lg' : 'text-lg'}`}>
+                        {page.description}
+                    </p>
+                )}
+            </header>
+
+            <div className='flex flex-col gap-8'>
+                {sections.map((section, index) => (
+                    <section key={section._id || `${section.type}-${index}`} className='scroll-mt-24'>
+                        {renderSection(section)}
+                    </section>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+PageRenderer.propTypes = {
+    page: PropTypes.shape({
+        title: PropTypes.string,
+        description: PropTypes.string,
+        sections: PropTypes.arrayOf(
+            PropTypes.shape({
+                _id: PropTypes.string,
+                type: PropTypes.string,
+                order: PropTypes.number,
+            })
+        ),
+    }),
+    compact: PropTypes.bool,
+};
+
+export default PageRenderer;

--- a/client/src/components/PageView.jsx
+++ b/client/src/components/PageView.jsx
@@ -1,0 +1,66 @@
+import PropTypes from 'prop-types';
+import { Alert, Spinner } from 'flowbite-react';
+import { useQuery } from '@tanstack/react-query';
+import PageRenderer from './PageRenderer.jsx';
+import { getPageContent } from '../services/pageService.js';
+
+const PageView = ({ slug, fallback }) => {
+    const {
+        data,
+        isLoading,
+        isError,
+        error,
+    } = useQuery({
+        queryKey: ['contentPage', slug],
+        queryFn: () => getPageContent(slug),
+        retry: (failureCount, err) => {
+            if (err?.response?.status === 404) {
+                return false;
+            }
+
+            return failureCount < 2;
+        },
+    });
+
+    if (isLoading) {
+        return (
+            <div className='flex min-h-[60vh] items-center justify-center'>
+                <Spinner size='xl' />
+            </div>
+        );
+    }
+
+    if (isError) {
+        if (error?.response?.status === 404) {
+            if (fallback) {
+                return <>{fallback}</>;
+            }
+
+            return (
+                <div className='mx-auto max-w-4xl px-4 py-16 text-center'>
+                    <h1 className='text-3xl font-semibold text-gray-900 dark:text-white'>Page coming soon</h1>
+                    <p className='mt-2 text-sm text-gray-500 dark:text-gray-400'>
+                        We&apos;re still crafting this experience. Please check back later.
+                    </p>
+                </div>
+            );
+        }
+
+        return (
+            <div className='mx-auto max-w-4xl px-4 py-16'>
+                <Alert color='failure'>
+                    {error?.response?.data?.message || error?.message || 'Failed to load the requested page.'}
+                </Alert>
+            </div>
+        );
+    }
+
+    return <PageRenderer page={data} />;
+};
+
+PageView.propTypes = {
+    slug: PropTypes.string.isRequired,
+    fallback: PropTypes.node,
+};
+
+export default PageView;

--- a/client/src/pages/About.jsx
+++ b/client/src/pages/About.jsx
@@ -1,40 +1,28 @@
 import CallToAction from '../components/CallToAction';
+import PageView from '../components/PageView.jsx';
+
+const AboutFallback = () => (
+    <div className='mx-auto flex min-h-screen max-w-3xl flex-col items-center gap-8 px-4 py-12 text-center sm:px-6'>
+        <h1 className='text-4xl font-bold text-gray-900 dark:text-white'>About ScientistShield</h1>
+        <div className='flex flex-col gap-6 text-lg text-gray-600 dark:text-gray-300'>
+            <p>
+                ScientistShield is a learning community built by curious developers who believe in sharing knowledge. We publish
+                hands-on tutorials, explore engineering best practices, and celebrate the creativity that powers scientific
+                discovery.
+            </p>
+            <p>
+                Each resource is crafted to help learners at every level move from theory to practice. Expect deep dives into web
+                development, interactive coding challenges, and curated study paths across emerging technologies.
+            </p>
+            <p>
+                We encourage discussion and collaboration. Comment on lessons, share your own breakthroughs, and help fellow
+                learners grow alongside you.
+            </p>
+        </div>
+        <CallToAction />
+    </div>
+);
 
 export default function About() {
-  return (
-    <div className='min-h-screen flex items-center justify-center'>
-      <div className='max-w-2xl mx-auto p-3 text-center'>
-        <div>
-          <h1 className='text-3xl font font-semibold text-center my-7'>
-            About Sahand's Blog
-          </h1>
-          <div className='text-md text-gray-500 flex flex-col gap-6'>
-            <p>
-              Welcome to Sahand's Blog! This blog was created by Sahand Ghavidel
-              as a personal project to share his thoughts and ideas with the
-              world. Sahand is a passionate developer who loves to write about
-              technology, coding, and everything in between.
-            </p>
-
-            <p>
-              On this blog, you'll find weekly articles and tutorials on topics
-              such as web development, software engineering, and programming
-              languages. Sahand is always learning and exploring new
-              technologies, so be sure to check back often for new content!
-            </p>
-
-            <p>
-              We encourage you to leave comments on our posts and engage with
-              other readers. You can like other people's comments and reply to
-              them as well. We believe that a community of learners can help
-              each other grow and improve.
-            </p>
-          </div>
-        </div>
-        <div className='mt-10'>
-          <CallToAction />
-        </div>
-      </div>
-    </div>
-  );
+    return <PageView slug='about' fallback={<AboutFallback />} />;
 }

--- a/client/src/pages/ContentPage.jsx
+++ b/client/src/pages/ContentPage.jsx
@@ -1,0 +1,9 @@
+import { useParams } from 'react-router-dom';
+import PageView from '../components/PageView.jsx';
+
+const ContentPage = () => {
+    const { slug } = useParams();
+    return <PageView slug={slug} />;
+};
+
+export default ContentPage;

--- a/client/src/pages/CreatePage.jsx
+++ b/client/src/pages/CreatePage.jsx
@@ -1,0 +1,43 @@
+import { useNavigate } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import { Alert } from 'flowbite-react';
+import PageForm from '../components/PageForm.jsx';
+import { createPage } from '../services/pageService.js';
+
+const CreatePage = () => {
+    const navigate = useNavigate();
+
+    const mutation = useMutation({
+        mutationFn: createPage,
+    });
+
+    const handleCreate = async (payload) => {
+        const createdPage = await mutation.mutateAsync(payload);
+        navigate(`/update-page/${createdPage._id}`);
+    };
+
+    return (
+        <div className='mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8'>
+            <div className='mb-6 flex flex-col gap-2'>
+                <h1 className='text-3xl font-semibold text-gray-900 dark:text-white'>Create a custom page</h1>
+                <p className='text-sm text-gray-500 dark:text-gray-400'>
+                    Compose tutorials, marketing pages, and curated resources with flexible drag-and-drop sections.
+                </p>
+            </div>
+
+            {mutation.isError && (
+                <Alert color='failure' className='mb-6'>
+                    {mutation.error?.response?.data?.message || mutation.error?.message || 'Failed to create the page.'}
+                </Alert>
+            )}
+
+            <PageForm
+                onSubmit={handleCreate}
+                isSubmitting={mutation.isPending}
+                submitLabel='Create page'
+            />
+        </div>
+    );
+};
+
+export default CreatePage;

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -12,6 +12,7 @@ const DashComments = lazy(() => import('../components/DashComments'));
 const DashboardComp = lazy(() => import('../components/DashboardComp'));
 const DashTutorials = lazy(() => import('../components/DashTutorials'));
 const DashQuizzes = lazy(() => import('../components/DashQuizzes')); // NEW: Import DashQuizzes component
+const DashPages = lazy(() => import('../components/DashPages'));
 
 // Create a map to associate tab names with their components.
 const componentMap = {
@@ -22,6 +23,7 @@ const componentMap = {
     dash: DashboardComp,
     tutorials: DashTutorials,
     quizzes: DashQuizzes, // NEW: Add DashQuizzes to the map
+    content: DashPages,
 };
 
 export default function Dashboard() {

--- a/client/src/pages/Projects.jsx
+++ b/client/src/pages/Projects.jsx
@@ -1,42 +1,37 @@
 import CallToAction from '../components/CallToAction';
+import PageView from '../components/PageView.jsx';
+
+const ProjectsFallback = () => (
+    <div className='mx-auto flex min-h-screen max-w-4xl flex-col items-center gap-8 px-4 py-12 text-center sm:px-6'>
+        <h1 className='text-4xl font-bold text-gray-900 dark:text-white'>Explore Our Projects</h1>
+        <p className='max-w-3xl text-lg text-gray-600 dark:text-gray-300'>
+            Dive into a collection of fun and engaging projects designed to help you learn and master HTML, CSS, and JavaScript.
+            Whether you&apos;re a beginner or an experienced developer, these projects will challenge your skills and inspire
+            creativity.
+        </p>
+        <div className='flex w-full flex-col gap-6'>
+            <section className='rounded-2xl bg-gray-100 p-6 text-left shadow-md dark:bg-gray-800/70'>
+                <h2 className='text-2xl font-semibold text-gray-900 dark:text-white'>Why build projects?</h2>
+                <p className='mt-2 text-gray-700 dark:text-gray-300'>
+                    Building projects is one of the best ways to learn programming. It allows you to apply theoretical knowledge
+                    in a practical way, solve real-world problems, and create a portfolio that showcases your skills.
+                </p>
+            </section>
+            <section className='rounded-2xl bg-gray-100 p-6 text-left shadow-md dark:bg-gray-800/70'>
+                <h2 className='text-2xl font-semibold text-gray-900 dark:text-white'>What you&apos;ll explore</h2>
+                <ul className='mt-3 list-disc space-y-2 pl-4 text-gray-700 dark:text-gray-300'>
+                    <li>Structuring semantic HTML for clarity</li>
+                    <li>Crafting responsive layouts with CSS</li>
+                    <li>Adding interactivity with JavaScript</li>
+                    <li>Debugging and problem-solving techniques</li>
+                    <li>Best practices for accessible web design</li>
+                </ul>
+            </section>
+        </div>
+        <CallToAction />
+    </div>
+);
 
 export default function Projects() {
-  return (
-    <div className='min-h-screen max-w-4xl mx-auto flex justify-center gap-8 items-center flex-col p-6'>
-      <h1 className='text-4xl font-bold text-center'>Explore Our Projects</h1>
-      <p className='text-lg text-gray-600 text-center max-w-3xl'>
-        Dive into a collection of fun and engaging projects designed to help you
-        learn and master HTML, CSS, and JavaScript. Whether you're a beginner or
-        an experienced developer, these projects will challenge your skills and
-        inspire creativity. Start building today and take your development
-        journey to the next level!
-      </p>
-      <div className='w-full flex flex-col gap-6'>
-        <section className='bg-gray-100 p-6 rounded-lg shadow-md'>
-          <h2 className='text-2xl font-semibold dark:text-gray-900'>
-            Why Build Projects?
-          </h2>
-          <p className='text-gray-700 mt-2'>
-            Building projects is one of the best ways to learn programming. It
-            allows you to apply theoretical knowledge in a practical way, solve
-            real-world problems, and create a portfolio that showcases your
-            skills to potential employers or clients.
-          </p>
-        </section>
-        <section className='bg-gray-100 p-6 rounded-lg shadow-md'>
-          <h2 className='text-2xl font-semibold dark:text-gray-900'>
-            What You'll Learn
-          </h2>
-          <ul className='list-disc list-inside text-gray-700 mt-2'>
-            <li>How to structure HTML for clean and semantic code</li>
-            <li>Styling with CSS to create visually appealing designs</li>
-            <li>Adding interactivity with JavaScript</li>
-            <li>Debugging and problem-solving techniques</li>
-            <li>Best practices for responsive and accessible web design</li>
-          </ul>
-        </section>
-      </div>
-      <CallToAction />
-    </div>
-  );
+    return <PageView slug='projects' fallback={<ProjectsFallback />} />;
 }

--- a/client/src/pages/UpdatePage.jsx
+++ b/client/src/pages/UpdatePage.jsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Alert, Spinner } from 'flowbite-react';
+import PageForm from '../components/PageForm.jsx';
+import { getPageById, updatePage } from '../services/pageService.js';
+
+const UpdatePage = () => {
+    const { pageId } = useParams();
+    const queryClient = useQueryClient();
+    const [successMessage, setSuccessMessage] = useState('');
+
+    const {
+        data,
+        isLoading,
+        isError,
+        error,
+    } = useQuery({
+        queryKey: ['adminPage', pageId],
+        queryFn: () => getPageById(pageId),
+        enabled: Boolean(pageId),
+    });
+
+    const mutation = useMutation({
+        mutationFn: (payload) => updatePage({ pageId, payload }),
+        onSuccess: (updatedPage) => {
+            queryClient.setQueryData(['adminPage', pageId], updatedPage);
+            queryClient.invalidateQueries({ queryKey: ['adminPages'] });
+
+            if (data?.slug) {
+                queryClient.invalidateQueries({ queryKey: ['contentPage', data.slug] });
+            }
+
+            queryClient.invalidateQueries({ queryKey: ['contentPage', updatedPage.slug] });
+            setSuccessMessage('Page updated successfully.');
+        },
+    });
+
+    const handleUpdate = async (payload) => {
+        await mutation.mutateAsync(payload);
+    };
+
+    if (isLoading) {
+        return (
+            <div className='flex min-h-[60vh] items-center justify-center'>
+                <Spinner size='xl' />
+            </div>
+        );
+    }
+
+    if (isError) {
+        return (
+            <div className='mx-auto max-w-4xl px-4 py-10'>
+                <Alert color='failure'>
+                    {error?.response?.data?.message || error?.message || 'Unable to load this page.'}
+                </Alert>
+            </div>
+        );
+    }
+
+    return (
+        <div className='mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8'>
+            <div className='mb-6 flex flex-col gap-2'>
+                <h1 className='text-3xl font-semibold text-gray-900 dark:text-white'>Edit page</h1>
+                <p className='text-sm text-gray-500 dark:text-gray-400'>
+                    Iterate on copy, visuals, and layout to keep your content fresh.
+                </p>
+            </div>
+
+            {successMessage && (
+                <Alert color='success' className='mb-6' onDismiss={() => setSuccessMessage('')}>
+                    {successMessage}
+                </Alert>
+            )}
+
+            {mutation.isError && (
+                <Alert color='failure' className='mb-6'>
+                    {mutation.error?.response?.data?.message || mutation.error?.message || 'Failed to update the page.'}
+                </Alert>
+            )}
+
+            <PageForm
+                initialValues={data}
+                onSubmit={handleUpdate}
+                isSubmitting={mutation.isPending}
+                submitLabel='Save changes'
+            />
+        </div>
+    );
+};
+
+export default UpdatePage;

--- a/client/src/services/pageService.js
+++ b/client/src/services/pageService.js
@@ -1,0 +1,59 @@
+import axios from 'axios';
+
+const API = axios.create({
+    baseURL: import.meta.env.VITE_API_URL ?? '',
+    withCredentials: true,
+});
+
+export const createPage = async (payload) => {
+    const { data } = await API.post('/api/pages', payload);
+    return data;
+};
+
+export const updatePage = async ({ pageId, payload }) => {
+    const { data } = await API.patch(`/api/pages/${pageId}`, payload);
+    return data;
+};
+
+export const deletePage = async (pageId) => {
+    const { data } = await API.delete(`/api/pages/${pageId}`);
+    return data;
+};
+
+export const getPages = async ({ queryKey, pageParam = 0 }) => {
+    const [, filters = {}] = queryKey;
+    const params = new URLSearchParams();
+
+    params.set('startIndex', pageParam.toString());
+    params.set('limit', (filters.limit ?? 10).toString());
+
+    if (filters.status && filters.status !== 'all') {
+        params.set('status', filters.status);
+    }
+
+    if (filters.search) {
+        params.set('searchTerm', filters.search);
+    }
+
+    const { data } = await API.get(`/api/pages?${params.toString()}`);
+    return data;
+};
+
+export const getPageById = async (pageId) => {
+    const { data } = await API.get(`/api/pages/${pageId}`);
+    return data;
+};
+
+export const getPageContent = async (slug) => {
+    const { data } = await API.get(`/api/content/${slug}`);
+    return data;
+};
+
+export default {
+    createPage,
+    updatePage,
+    deletePage,
+    getPages,
+    getPageById,
+    getPageContent,
+};

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -91,3 +91,40 @@ export interface QuizSubmissionResult {
     results: QuestionResult[];
     message: string;
 }
+
+export interface PageSectionItem {
+    title?: string;
+    body?: string;
+    icon?: string;
+}
+
+export interface PageSection {
+    _id?: string;
+    type: 'hero' | 'rich-text' | 'feature-grid' | 'cta' | 'custom';
+    title?: string;
+    subtitle?: string;
+    body?: string;
+    alignment?: 'left' | 'center' | 'right';
+    background?: string;
+    media?: {
+        url?: string;
+        alt?: string;
+    };
+    cta?: {
+        label?: string;
+        url?: string;
+    };
+    items?: PageSectionItem[];
+    order?: number;
+}
+
+export interface PageContent {
+    _id: string;
+    title: string;
+    slug: string;
+    description?: string;
+    status: 'draft' | 'published';
+    sections: PageSection[];
+    createdAt: string;
+    updatedAt: string;
+}

--- a/client/src/utils/slugify.js
+++ b/client/src/utils/slugify.js
@@ -1,0 +1,9 @@
+const slugify = (value = '') =>
+    value
+        .toString()
+        .toLowerCase()
+        .trim()
+        .replace(/[\s\W-]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+
+export default slugify;

--- a/client/types.ts
+++ b/client/types.ts
@@ -39,3 +39,40 @@ export interface Tutorial {
     createdAt: string;
     updatedAt: string;
 }
+
+export interface PageSectionItem {
+    title?: string;
+    body?: string;
+    icon?: string;
+}
+
+export interface PageSection {
+    _id?: string;
+    type: 'hero' | 'rich-text' | 'feature-grid' | 'cta' | 'custom';
+    title?: string;
+    subtitle?: string;
+    body?: string;
+    alignment?: 'left' | 'center' | 'right';
+    background?: string;
+    media?: {
+        url?: string;
+        alt?: string;
+    };
+    cta?: {
+        label?: string;
+        url?: string;
+    };
+    items?: PageSectionItem[];
+    order?: number;
+}
+
+export interface PageContent {
+    _id: string;
+    title: string;
+    slug: string;
+    description?: string;
+    status: 'draft' | 'published';
+    sections: PageSection[];
+    createdAt: string;
+    updatedAt: string;
+}


### PR DESCRIPTION
## Summary
- add a new Page mongoose model, controller, and routes to manage custom CMS content with public slug access
- introduce React admin tools (DashPages, PageForm, PageRenderer) and services for creating, editing, previewing, and deleting pages
- update navigation and public routes to surface dynamic CMS pages, and convert About/Projects to fall back on CMS-driven content

## Testing
- MONGO_URI=mongodb://127.0.0.1:27017/test CORS_ORIGIN=http://localhost:5173 PORT=3000 JWT_SECRET=secret npm test

------
https://chatgpt.com/codex/tasks/task_b_68cb6c771754832d9b9ae7d80e5bede1