### PR TITLE
Add admin control panel experience

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -38,6 +38,7 @@ const TryItPage = lazy(() => import('./pages/TryItPage'));
 const CreatePage = lazy(() => import('./pages/CreatePage'));
 const UpdatePage = lazy(() => import('./pages/UpdatePage'));
 const ContentPage = lazy(() => import('./pages/ContentPage'));
+const AdminPanel = lazy(() => import('./pages/AdminPanel'));
 
 // A fallback component to show while pages are loading
 const LoadingFallback = () => (
@@ -78,6 +79,7 @@ export default function App() {
 
                         {/* Admin Routes also use the main layout */}
                         <Route element={<OnlyAdminPrivateRoute />}>
+                            <Route path="admin" element={<AdminPanel />} />
                             <Route path="create-post" element={<CreatePost />} />
                             <Route path="update-post/:postId" element={<UpdatePost />} />
                             {/* Admin Tutorial Routes */}

--- a/client/src/components/CommandMenu.jsx
+++ b/client/src/components/CommandMenu.jsx
@@ -1,18 +1,35 @@
 // client/src/components/CommandMenu.jsx
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Modal, TextInput } from 'flowbite-react';
 import { AiOutlineSearch } from 'react-icons/ai';
+import { useSelector } from 'react-redux';
 
 const CommandMenu = ({ isOpen, onClose }) => {
     const navigate = useNavigate();
     const [searchTerm, setSearchTerm] = useState('');
     const modalRef = useRef(null);
+    const { currentUser } = useSelector((state) => state.user);
 
-    const quickLinks = [
-        { label: 'Profile', path: '/dashboard?tab=profile' },
-        { label: 'Create a Post', path: '/create-post' },
-    ];
+    const quickLinks = useMemo(() => {
+        if (currentUser?.isAdmin) {
+            return [
+                { label: 'Admin Panel', path: '/admin' },
+                { label: 'Dashboard overview', path: '/dashboard?tab=dash' },
+                { label: 'Profile', path: '/dashboard?tab=profile' },
+                { label: 'Manage posts', path: '/dashboard?tab=posts' },
+                { label: 'Create a Post', path: '/create-post' },
+                { label: 'Create a Tutorial', path: '/create-tutorial' },
+                { label: 'Create a Quiz', path: '/create-quiz' },
+                { label: 'Create a Page', path: '/create-page' },
+            ];
+        }
+
+        return [
+            { label: 'Profile', path: '/dashboard?tab=profile' },
+            { label: 'Create a Post', path: '/create-post' },
+        ];
+    }, [currentUser]);
 
     const handleSubmit = (e) => {
         e.preventDefault();

--- a/client/src/components/DashboardComp.jsx
+++ b/client/src/components/DashboardComp.jsx
@@ -1,78 +1,21 @@
-import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { HiAnnotation, HiCollection, HiDocumentText, HiOutlineUserGroup } from 'react-icons/hi';
 import { Alert, Badge, Spinner, Table } from 'flowbite-react';
 import StatCard from './StatCard'; // Import new component
 import RecentDataTable from './RecentDataTable'; // Import new component
+import useAdminDashboardData from '../hooks/useAdminDashboardData';
 
 export default function DashboardComp() {
   const { currentUser } = useSelector((state) => state.user);
-  const [dashboardData, setDashboardData] = useState({
-    users: [],
-    comments: [],
-    posts: [],
-    pages: [],
-    totalUsers: 0,
-    totalPosts: 0,
-    totalComments: 0,
-    totalPages: 0,
-    lastMonthUsers: 0,
-    lastMonthPosts: 0,
-    lastMonthComments: 0,
-    lastMonthPages: 0,
-  });
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const { data: dashboardData, loading, error } = useAdminDashboardData(Boolean(currentUser?.isAdmin));
 
-  useEffect(() => {
-    const fetchData = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        // Fetch all data concurrently for better performance
-        const [userRes, postRes, commentRes, pageRes] = await Promise.all([
-          fetch('/api/user/getusers?limit=5'),
-          fetch('/api/post/getposts?limit=5'),
-          fetch('/api/comment/getcomments?limit=5'),
-          fetch('/api/pages?limit=5', { credentials: 'include' }),
-        ]);
-
-        const userData = await userRes.json();
-        const postData = await postRes.json();
-        const commentData = await commentRes.json();
-        const pageData = await pageRes.json();
-
-        if (userRes.ok && postRes.ok && commentRes.ok && pageRes.ok) {
-          setDashboardData({
-            users: userData.users,
-            totalUsers: userData.totalUsers,
-            lastMonthUsers: userData.lastMonthUsers,
-            posts: postData.posts,
-            totalPosts: postData.totalPosts,
-            lastMonthPosts: postData.lastMonthPosts,
-            comments: commentData.comments,
-            totalComments: commentData.totalComments,
-            lastMonthComments: commentData.lastMonthComments,
-            pages: pageData.pages,
-            totalPages: pageData.totalCount,
-            lastMonthPages: pageData.lastMonthCount,
-          });
-        } else {
-          // Handle potential errors from the API responses
-          setError('Failed to fetch some data. Please try again.');
-          console.error('API Error:', { userData, postData, commentData, pageData });
-        }
-      } catch (err) {
-        setError(err.message);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    if (currentUser.isAdmin) {
-      fetchData();
-    }
-  }, [currentUser]);
+  if (!currentUser?.isAdmin) {
+    return (
+        <div className='p-3 md:mx-auto'>
+          <Alert color='warning'>Administrator access required.</Alert>
+        </div>
+    );
+  }
 
   if (loading) {
     return (

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -260,6 +260,21 @@ export default function Header() {
                           </span>
                               </div>
                               <hr className="dark:border-gray-600" />
+                              {currentUser.isAdmin && (
+                                  <>
+                                    <Link to={'/admin'} onClick={() => setIsDropdownOpen(false)}>
+                                      <div className="block px-space-lg py-space-sm text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 cursor-pointer">
+                                        Admin Panel
+                                      </div>
+                                    </Link>
+                                    <Link to={'/dashboard?tab=dash'} onClick={() => setIsDropdownOpen(false)}>
+                                      <div className="block px-space-lg py-space-sm text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 cursor-pointer">
+                                        Dashboard
+                                      </div>
+                                    </Link>
+                                    <hr className="dark:border-gray-600" />
+                                  </>
+                              )}
                               <Link to={'/dashboard?tab=profile'} onClick={() => setIsDropdownOpen(false)}>
                                 <div className="block px-space-lg py-space-sm text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 cursor-pointer">
                                   Profile

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -13,7 +13,8 @@ import {
     FaRegBell,
     FaRegFileAlt,
     FaRegCreditCard,
-    FaThumbtack
+    FaThumbtack,
+    FaShieldAlt,
 } from 'react-icons/fa';
 import { Avatar, Tooltip, Button } from 'flowbite-react';
 
@@ -305,11 +306,25 @@ const Sidebar = ({ isCollapsed, isPinned, setIsPinned }) => {
 
             <nav className="flex-1 p-2 space-y-1 overflow-y-auto">
                 <SectionHeader label="Main" isCollapsed={isCollapsed} />
-                <CollapsibleNavItem icon={FaTachometerAlt} label="Dashboard" isCollapsed={isCollapsed}>
-                    <SubItem to="/dashboard?tab=activity" label="Activity" />
-                    <SubItem to="/dashboard?tab=traffic" label="Traffic" />
-                    <SubItem to="/dashboard?tab=statistic" label="Statistic" />
-                </CollapsibleNavItem>
+                {currentUser?.isAdmin && (
+                    <>
+                        <NavItem
+                            to="/admin"
+                            icon={FaShieldAlt}
+                            label="Admin Panel"
+                            isCollapsed={isCollapsed}
+                        />
+                        <CollapsibleNavItem icon={FaTachometerAlt} label="Dashboard" isCollapsed={isCollapsed}>
+                            <SubItem to="/dashboard?tab=dash" label="Overview" />
+                            <SubItem to="/dashboard?tab=posts" label="Posts" />
+                            <SubItem to="/dashboard?tab=tutorials" label="Tutorials" />
+                            <SubItem to="/dashboard?tab=quizzes" label="Quizzes" />
+                            <SubItem to="/dashboard?tab=content" label="Content" />
+                            <SubItem to="/dashboard?tab=comments" label="Comments" />
+                            <SubItem to="/dashboard?tab=users" label="Users" />
+                        </CollapsibleNavItem>
+                    </>
+                )}
 
                 {mainNavItems.map(item => <NavItem key={item.to} {...item} isCollapsed={isCollapsed} />)}
 

--- a/client/src/hooks/useAdminDashboardData.js
+++ b/client/src/hooks/useAdminDashboardData.js
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+const defaultDashboardState = Object.freeze({
+    users: [],
+    posts: [],
+    comments: [],
+    pages: [],
+    tutorials: [],
+    quizzes: [],
+    totalUsers: 0,
+    totalPosts: 0,
+    totalComments: 0,
+    totalPages: 0,
+    totalTutorials: 0,
+    totalQuizzes: 0,
+    lastMonthUsers: 0,
+    lastMonthPosts: 0,
+    lastMonthComments: 0,
+    lastMonthPages: 0,
+    lastMonthTutorials: 0,
+    lastMonthQuizzes: 0,
+});
+
+export default function useAdminDashboardData(isEnabled) {
+    const [data, setData] = useState(defaultDashboardState);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const [lastSynced, setLastSynced] = useState(null);
+
+    const fetchData = useCallback(async () => {
+        if (!isEnabled) {
+            return;
+        }
+
+        setLoading(true);
+        setError(null);
+
+        try {
+            const [userRes, postRes, commentRes, pageRes, tutorialRes, quizRes] = await Promise.all([
+                fetch('/api/user/getusers?limit=5'),
+                fetch('/api/post/getposts?limit=5'),
+                fetch('/api/comment/getcomments?limit=5'),
+                fetch('/api/pages?limit=5', { credentials: 'include' }),
+                fetch('/api/tutorial/gettutorials?limit=5'),
+                fetch('/api/quiz/quizzes?limit=5'),
+            ]);
+
+            const [userData, postData, commentData, pageData, tutorialData, quizData] = await Promise.all([
+                userRes.json(),
+                postRes.json(),
+                commentRes.json(),
+                pageRes.json(),
+                tutorialRes.json(),
+                quizRes.json(),
+            ]);
+
+            if (!userRes.ok || !postRes.ok || !commentRes.ok || !pageRes.ok || !tutorialRes.ok || !quizRes.ok) {
+                const message =
+                    userData.message ||
+                    postData.message ||
+                    commentData.message ||
+                    pageData.message ||
+                    tutorialData.message ||
+                    quizData.message ||
+                    'Failed to fetch admin metrics. Please try again.';
+                throw new Error(message);
+            }
+
+            setData({
+                users: userData.users || [],
+                posts: postData.posts || [],
+                comments: commentData.comments || [],
+                pages: pageData.pages || [],
+                tutorials: tutorialData.tutorials || [],
+                quizzes: quizData.quizzes || [],
+                totalUsers: userData.totalUsers || 0,
+                totalPosts: postData.totalPosts || 0,
+                totalComments: commentData.totalComments || 0,
+                totalPages: pageData.totalCount || 0,
+                totalTutorials: tutorialData.totalTutorials || 0,
+                totalQuizzes: quizData.totalQuizzes || 0,
+                lastMonthUsers: userData.lastMonthUsers || 0,
+                lastMonthPosts: postData.lastMonthPosts || 0,
+                lastMonthComments: commentData.lastMonthComments || 0,
+                lastMonthPages: pageData.lastMonthCount || 0,
+                lastMonthTutorials: tutorialData.lastMonthTutorials || 0,
+                lastMonthQuizzes: quizData.lastMonthQuizzes || 0,
+            });
+            setLastSynced(new Date());
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Unexpected error while loading admin data.');
+        } finally {
+            setLoading(false);
+        }
+    }, [isEnabled]);
+
+    useEffect(() => {
+        if (isEnabled) {
+            fetchData();
+        }
+    }, [isEnabled, fetchData]);
+
+    return useMemo(
+        () => ({
+            data,
+            loading,
+            error,
+            refetch: fetchData,
+            lastSynced,
+        }),
+        [data, error, fetchData, lastSynced, loading],
+    );
+}

--- a/client/src/pages/AdminPanel.jsx
+++ b/client/src/pages/AdminPanel.jsx
@@ -1,0 +1,371 @@
+import { Alert, Badge, Button, Spinner, Table } from 'flowbite-react';
+import { useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
+import {
+    HiAcademicCap,
+    HiAnnotation,
+    HiArrowRight,
+    HiChartPie,
+    HiCollection,
+    HiDocumentText,
+    HiOutlineUserGroup,
+    HiPuzzle,
+    HiRefresh,
+} from 'react-icons/hi';
+import StatCard from '../components/StatCard';
+import RecentDataTable from '../components/RecentDataTable';
+import useAdminDashboardData from '../hooks/useAdminDashboardData';
+
+const quickActions = [
+    {
+        title: 'Publish a post',
+        description: 'Share announcements, updates, and longer-form articles with the community.',
+        to: '/create-post',
+        icon: HiDocumentText,
+        gradient: 'from-sky-500 via-cyan-500 to-blue-500',
+    },
+    {
+        title: 'Launch a tutorial',
+        description: 'Curate a structured learning path with interactive chapters and resources.',
+        to: '/create-tutorial',
+        icon: HiAcademicCap,
+        gradient: 'from-emerald-500 via-teal-500 to-green-500',
+    },
+    {
+        title: 'Build a quiz',
+        description: 'Evaluate learner progress with configurable question banks and scoring.',
+        to: '/create-quiz',
+        icon: HiPuzzle,
+        gradient: 'from-violet-500 via-indigo-500 to-purple-500',
+    },
+    {
+        title: 'Design a page',
+        description: 'Create marketing or documentation pages with modular content sections.',
+        to: '/create-page',
+        icon: HiCollection,
+        gradient: 'from-amber-500 via-orange-500 to-rose-500',
+    },
+];
+
+const managementShortcuts = [
+    {
+        title: 'Manage users',
+        description: 'Review roles, promote moderators, and keep membership healthy.',
+        to: '/dashboard?tab=users',
+        icon: HiOutlineUserGroup,
+    },
+    {
+        title: 'Moderate comments',
+        description: 'Respond to feedback and resolve reports from the moderation queue.',
+        to: '/dashboard?tab=comments',
+        icon: HiAnnotation,
+    },
+    {
+        title: 'Posts library',
+        description: 'Edit existing articles, update metadata, or retire outdated posts.',
+        to: '/dashboard?tab=posts',
+        icon: HiDocumentText,
+    },
+    {
+        title: 'Tutorial catalog',
+        description: 'Reorder chapters, attach quizzes, and refine the learning experience.',
+        to: '/dashboard?tab=tutorials',
+        icon: HiAcademicCap,
+    },
+    {
+        title: 'Quiz insights',
+        description: 'Audit question pools and align assessments with tutorials.',
+        to: '/dashboard?tab=quizzes',
+        icon: HiPuzzle,
+    },
+    {
+        title: 'Content pages',
+        description: 'Publish marketing, onboarding, or help center pages with confidence.',
+        to: '/dashboard?tab=content',
+        icon: HiCollection,
+    },
+];
+
+export default function AdminPanel() {
+    const { currentUser } = useSelector((state) => state.user);
+    const { data, loading, error, refetch, lastSynced } = useAdminDashboardData(Boolean(currentUser?.isAdmin));
+
+    if (!currentUser?.isAdmin) {
+        return (
+            <div className='min-h-screen px-4 py-10'>
+                <div className='mx-auto max-w-3xl'>
+                    <Alert color='warning'>Administrator access required.</Alert>
+                </div>
+            </div>
+        );
+    }
+
+    const lastSyncedLabel = lastSynced
+        ? new Intl.DateTimeFormat('en', { dateStyle: 'medium', timeStyle: 'short' }).format(lastSynced)
+        : 'Awaiting first sync';
+
+    return (
+        <div className='min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 dark:from-slate-900 dark:via-slate-900 dark:to-slate-950 py-10'>
+            <div className='mx-auto max-w-7xl space-y-12 px-4 sm:px-6 lg:px-8'>
+                <header className='flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between'>
+                    <div className='space-y-4'>
+                        <span className='inline-flex items-center gap-2 rounded-full bg-cyan-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-200'>
+                            Control Center
+                        </span>
+                        <div>
+                            <h1 className='text-3xl font-bold text-gray-900 dark:text-white sm:text-4xl'>
+                                Welcome back, {currentUser.username}
+                            </h1>
+                            <p className='mt-2 max-w-2xl text-base text-gray-600 dark:text-gray-400'>
+                                Monitor platform health, publish new learning material, and keep your community thriving from a single hub.
+                            </p>
+                        </div>
+                        <div className='flex flex-wrap items-center gap-3 text-sm text-gray-500 dark:text-gray-400'>
+                            <span className='inline-flex items-center gap-2 rounded-full bg-white/80 px-3 py-1 shadow-sm ring-1 ring-gray-200 backdrop-blur dark:bg-white/5 dark:ring-white/10'>
+                                <HiChartPie className='h-4 w-4 text-cyan-500' />
+                                Metrics update automatically
+                            </span>
+                            <span>
+                                Last synced:
+                                <span className='ml-1 font-medium text-gray-700 dark:text-gray-200'>{lastSyncedLabel}</span>
+                            </span>
+                        </div>
+                    </div>
+                    <div className='flex flex-wrap items-center gap-3'>
+                        <Link to='/dashboard?tab=dash'>
+                            <Button color='light' className='w-full sm:w-auto'>
+                                Open dashboard overview
+                            </Button>
+                        </Link>
+                        <Button gradientDuoTone='purpleToBlue' onClick={refetch} disabled={loading}>
+                            <HiRefresh className={`mr-2 h-5 w-5 ${loading ? 'animate-spin' : ''}`} />
+                            Refresh data
+                        </Button>
+                    </div>
+                </header>
+
+                {error && (
+                    <Alert color='failure'>
+                        <span className='font-semibold'>Heads up:</span> {error}
+                    </Alert>
+                )}
+
+                <section className='space-y-4'>
+                    <div className='flex items-center justify-between gap-4'>
+                        <h2 className='text-xl font-semibold text-gray-900 dark:text-white'>Quick actions</h2>
+                        <p className='text-sm text-gray-500 dark:text-gray-400'>Ship work faster with curated shortcuts.</p>
+                    </div>
+                    <div className='grid gap-4 md:grid-cols-2 xl:grid-cols-4'>
+                        {quickActions.map((action) => (
+                            <Link
+                                key={action.title}
+                                to={action.to}
+                                className='group focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900'
+                            >
+                                <div
+                                    className={`relative overflow-hidden rounded-2xl bg-gradient-to-br ${action.gradient} p-6 text-white shadow-lg transition-all duration-200 group-hover:-translate-y-1 group-hover:shadow-xl`}
+                                >
+                                    <div className='flex items-start justify-between'>
+                                        <div>
+                                            <p className='text-xs font-semibold uppercase tracking-wider text-white/70'>Quick action</p>
+                                            <h3 className='mt-1 text-xl font-semibold'>{action.title}</h3>
+                                        </div>
+                                        <action.icon className='h-10 w-10 text-white/90' />
+                                    </div>
+                                    <p className='mt-4 text-sm text-white/80'>{action.description}</p>
+                                    <span className='mt-6 inline-flex items-center text-sm font-semibold text-white/90'>
+                                        Open workspace
+                                        <HiArrowRight className='ml-2 h-4 w-4 transition-transform duration-200 group-hover:translate-x-1' />
+                                    </span>
+                                </div>
+                            </Link>
+                        ))}
+                    </div>
+                </section>
+
+                <section className='space-y-4'>
+                    <div className='flex items-center justify-between gap-4'>
+                        <h2 className='text-xl font-semibold text-gray-900 dark:text-white'>Platform overview</h2>
+                        <p className='text-sm text-gray-500 dark:text-gray-400'>Track growth and engagement at a glance.</p>
+                    </div>
+                    <div className='grid gap-4 md:grid-cols-2 xl:grid-cols-3'>
+                        <StatCard
+                            title='Community members'
+                            count={data.totalUsers}
+                            lastMonthCount={data.lastMonthUsers}
+                            icon={HiOutlineUserGroup}
+                            iconBgColor='bg-sky-600'
+                            loading={loading}
+                        />
+                        <StatCard
+                            title='Posts published'
+                            count={data.totalPosts}
+                            lastMonthCount={data.lastMonthPosts}
+                            icon={HiDocumentText}
+                            iconBgColor='bg-indigo-600'
+                            loading={loading}
+                        />
+                        <StatCard
+                            title='Comments logged'
+                            count={data.totalComments}
+                            lastMonthCount={data.lastMonthComments}
+                            icon={HiAnnotation}
+                            iconBgColor='bg-amber-600'
+                            loading={loading}
+                        />
+                        <StatCard
+                            title='Tutorials live'
+                            count={data.totalTutorials}
+                            lastMonthCount={data.lastMonthTutorials}
+                            icon={HiAcademicCap}
+                            iconBgColor='bg-emerald-600'
+                            loading={loading}
+                        />
+                        <StatCard
+                            title='Active quizzes'
+                            count={data.totalQuizzes}
+                            lastMonthCount={data.lastMonthQuizzes}
+                            icon={HiPuzzle}
+                            iconBgColor='bg-purple-600'
+                            loading={loading}
+                        />
+                        <StatCard
+                            title='Content pages'
+                            count={data.totalPages}
+                            lastMonthCount={data.lastMonthPages}
+                            icon={HiCollection}
+                            iconBgColor='bg-rose-600'
+                            loading={loading}
+                        />
+                    </div>
+                </section>
+
+                <section className='space-y-4'>
+                    <div className='flex items-center justify-between gap-4'>
+                        <h2 className='text-xl font-semibold text-gray-900 dark:text-white'>Latest activity</h2>
+                        <p className='text-sm text-gray-500 dark:text-gray-400'>Recent additions across your knowledge base.</p>
+                    </div>
+                    {loading ? (
+                        <div className='flex justify-center rounded-2xl border border-dashed border-gray-300 p-10 dark:border-gray-700'>
+                            <Spinner size='lg' />
+                        </div>
+                    ) : (
+                        <div className='grid gap-6 lg:grid-cols-2'>
+                            <RecentDataTable
+                                title='Recent posts'
+                                linkTo='/dashboard?tab=posts'
+                                headers={['Post', 'Category']}
+                                data={data.posts}
+                                renderRow={(post) => (
+                                    <Table.Body key={post._id} className='divide-y'>
+                                        <Table.Row className='bg-white dark:border-gray-700 dark:bg-gray-800'>
+                                            <Table.Cell className='w-72'>
+                                                <div className='flex items-center gap-3'>
+                                                    <img
+                                                        src={post.image}
+                                                        alt={post.title}
+                                                        className='h-10 w-14 rounded-md object-cover'
+                                                    />
+                                                    <p className='line-clamp-2 font-medium'>{post.title}</p>
+                                                </div>
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                <Badge color='info' className='capitalize'>
+                                                    {post.category || 'general'}
+                                                </Badge>
+                                            </Table.Cell>
+                                        </Table.Row>
+                                    </Table.Body>
+                                )}
+                            />
+                            <RecentDataTable
+                                title='Recent tutorials'
+                                linkTo='/dashboard?tab=tutorials'
+                                headers={['Tutorial', 'Category']}
+                                data={data.tutorials}
+                                renderRow={(tutorial) => (
+                                    <Table.Body key={tutorial._id} className='divide-y'>
+                                        <Table.Row className='bg-white dark:border-gray-700 dark:bg-gray-800'>
+                                            <Table.Cell className='w-72'>
+                                                <p className='font-medium'>{tutorial.title}</p>
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                <Badge color='purple' className='capitalize'>
+                                                    {tutorial.category || 'general'}
+                                                </Badge>
+                                            </Table.Cell>
+                                        </Table.Row>
+                                    </Table.Body>
+                                )}
+                            />
+                            <RecentDataTable
+                                title='Recent quizzes'
+                                linkTo='/dashboard?tab=quizzes'
+                                headers={['Quiz', 'Questions']}
+                                data={data.quizzes}
+                                renderRow={(quiz) => (
+                                    <Table.Body key={quiz._id} className='divide-y'>
+                                        <Table.Row className='bg-white dark:border-gray-700 dark:bg-gray-800'>
+                                            <Table.Cell className='w-72'>
+                                                <p className='font-medium'>{quiz.title}</p>
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                <Badge color='success'>
+                                                    {quiz.questions?.length ?? 0} items
+                                                </Badge>
+                                            </Table.Cell>
+                                        </Table.Row>
+                                    </Table.Body>
+                                )}
+                            />
+                            <RecentDataTable
+                                title='Recent pages'
+                                linkTo='/dashboard?tab=content'
+                                headers={['Title', 'Status']}
+                                data={data.pages}
+                                renderRow={(page) => (
+                                    <Table.Body key={page._id} className='divide-y'>
+                                        <Table.Row className='bg-white dark:border-gray-700 dark:bg-gray-800'>
+                                            <Table.Cell className='w-72'>
+                                                <p className='font-medium'>{page.title}</p>
+                                            </Table.Cell>
+                                            <Table.Cell>
+                                                <Badge color={page.status === 'published' ? 'success' : 'warning'} className='capitalize'>
+                                                    {page.status}
+                                                </Badge>
+                                            </Table.Cell>
+                                        </Table.Row>
+                                    </Table.Body>
+                                )}
+                            />
+                        </div>
+                    )}
+                </section>
+
+                <section className='space-y-4 pb-6'>
+                    <div className='flex items-center justify-between gap-4'>
+                        <h2 className='text-xl font-semibold text-gray-900 dark:text-white'>Operational shortcuts</h2>
+                        <p className='text-sm text-gray-500 dark:text-gray-400'>Deep links into the management areas you visit most.</p>
+                    </div>
+                    <div className='grid gap-4 md:grid-cols-2 xl:grid-cols-3'>
+                        {managementShortcuts.map((item) => (
+                            <Link
+                                key={item.title}
+                                to={item.to}
+                                className='group rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition-all duration-200 hover:border-cyan-500 hover:shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-gray-700 dark:bg-slate-900/80 dark:hover:border-cyan-400 dark:focus-visible:ring-offset-slate-900'
+                            >
+                                <div className='flex items-start justify-between gap-4'>
+                                    <div>
+                                        <h3 className='text-lg font-semibold text-gray-900 dark:text-white'>{item.title}</h3>
+                                        <p className='mt-2 text-sm text-gray-500 dark:text-gray-400'>{item.description}</p>
+                                    </div>
+                                    <item.icon className='h-8 w-8 text-cyan-500 transition-colors duration-200 group-hover:text-cyan-400' />
+                                </div>
+                            </Link>
+                        ))}
+                    </div>
+                </section>
+            </div>
+        </div>
+    );
+}

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState, lazy, Suspense } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Spinner } from 'flowbite-react';
 import DashSidebar from '../components/DashSidebar';
+import { useSelector } from 'react-redux';
 
 // Dynamically import components using React.lazy
 const DashProfile = lazy(() => import('../components/DashProfile'));
@@ -29,12 +30,14 @@ const componentMap = {
 export default function Dashboard() {
     const location = useLocation();
     const [tab, setTab] = useState('');
+    const { currentUser } = useSelector((state) => state.user);
 
     useEffect(() => {
         const urlParams = new URLSearchParams(location.search);
         const tabFromUrl = urlParams.get('tab');
-        setTab(tabFromUrl || 'dash');
-    }, [location.search]);
+        const defaultTab = currentUser?.isAdmin ? 'dash' : 'profile';
+        setTab(tabFromUrl || defaultTab);
+    }, [location.search, currentUser]);
 
     const ActiveComponent = componentMap[tab];
 


### PR DESCRIPTION
## Summary
- add a dedicated Admin Panel page with quick actions, analytics cards, and recent activity tables for administrators
- centralize admin metrics fetching in a reusable `useAdminDashboardData` hook and update the dashboard to consume it
- surface the new panel and admin routes throughout the UI via the sidebar, header dropdown, and command menu while improving default dashboard navigation

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68cb73947eb0832db5155af8b169b5ab