### PR TITLE
Fix admin panel data fetching auth

### DIFF
--- a/client/src/hooks/useAdminDashboardData.js
+++ b/client/src/hooks/useAdminDashboardData.js
@@ -36,11 +36,13 @@ export default function useAdminDashboardData(isEnabled) {
         setError(null);
 
         try {
+            const authRequestOptions = { credentials: 'include' };
+
             const [userRes, postRes, commentRes, pageRes, tutorialRes, quizRes] = await Promise.all([
-                fetch('/api/user/getusers?limit=5'),
-                fetch('/api/post/getposts?limit=5'),
-                fetch('/api/comment/getcomments?limit=5'),
-                fetch('/api/pages?limit=5', { credentials: 'include' }),
+                fetch('/api/user/getusers?limit=5', authRequestOptions),
+                fetch('/api/post/getposts?limit=5', authRequestOptions),
+                fetch('/api/comment/getcomments?limit=5', authRequestOptions),
+                fetch('/api/pages?limit=5', authRequestOptions),
                 fetch('/api/tutorial/gettutorials?limit=5'),
                 fetch('/api/quiz/quizzes?limit=5'),
             ]);


### PR DESCRIPTION
## Summary
- ensure admin dashboard metrics requests include authentication credentials
- reuse shared request options for protected admin endpoints

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cbb15a87d4832dbb447b2a54b4a868