### PR TITLE
Fix admin dashboard quiz metrics fetch

### DIFF
--- a/client/src/hooks/useAdminDashboardData.js
+++ b/client/src/hooks/useAdminDashboardData.js
@@ -44,7 +44,7 @@ export default function useAdminDashboardData(isEnabled) {
                 fetch('/api/comment/getcomments?limit=5', authRequestOptions),
                 fetch('/api/pages?limit=5', authRequestOptions),
                 fetch('/api/tutorial/gettutorials?limit=5'),
-                fetch('/api/quiz/quizzes?limit=5'),
+                fetch('/api/quizzes?limit=5'),
             ]);
 
             const [userData, postData, commentData, pageData, tutorialData, quizData] = await Promise.all([


### PR DESCRIPTION
## Summary
- correct the quiz metrics fetch URL in the admin dashboard data hook so it targets the mounted /api/quizzes endpoint
- ensure aggregated dashboard data loads successfully for the platform overview and latest activity sections

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68cbb39a6d58832d8b335ce58acf23c4