### PR TITLE
Add embedded code visualizer experience

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -35,6 +35,7 @@ const UpdateQuiz = lazy(() => import('./pages/UpdateQuiz'));
 
 // NEW: Lazy load the Try it Yourself page
 const TryItPage = lazy(() => import('./pages/TryItPage'));
+const CodeVisualizer = lazy(() => import('./pages/CodeVisualizer'));
 const CreatePage = lazy(() => import('./pages/CreatePage'));
 const UpdatePage = lazy(() => import('./pages/UpdatePage'));
 const ContentPage = lazy(() => import('./pages/ContentPage'));
@@ -70,6 +71,7 @@ export default function App() {
 
                         {/* NEW: Try It Yourself Route */}
                         <Route path="tryit" element={<TryItPage />} />
+                        <Route path="visualizer" element={<CodeVisualizer />} />
                         <Route path="content/:slug" element={<ContentPage />} />
 
                         {/* Private Routes also use the main layout */}

--- a/client/src/components/BottomNav.jsx
+++ b/client/src/components/BottomNav.jsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from 'react-router-dom';
-import { FaBook, FaHome, FaQuestionCircle, FaUser } from 'react-icons/fa';
+import { FaBook, FaHome, FaQuestionCircle, FaUser, FaLaptopCode } from 'react-icons/fa';
 import { useSelector } from 'react-redux';
 import { motion } from 'framer-motion';
 import ThemeToggle from './ThemeToggle.jsx';
@@ -8,7 +8,8 @@ import ThemeToggle from './ThemeToggle.jsx';
 const items = [
     { to: '/', label: 'Home', icon: FaHome },
     { to: '/tutorials', label: 'Tutorials', icon: FaBook },
-    { to: '/quizzes', label: 'Quizzes', icon: FaQuestionCircle }
+    { to: '/quizzes', label: 'Quizzes', icon: FaQuestionCircle },
+    { to: '/visualizer', label: 'Visualizer', icon: FaLaptopCode }
 ];
 
 export default function BottomNav() {

--- a/client/src/components/CodeEditor.jsx
+++ b/client/src/components/CodeEditor.jsx
@@ -3,8 +3,9 @@ import React, { useState, useEffect, useRef } from 'react';
 import Editor from '@monaco-editor/react';
 import { Button, ToggleSwitch, Spinner, Alert } from 'flowbite-react';
 import { useSelector } from 'react-redux';
-import { FaPlay, FaRedo, FaChevronRight, FaChevronDown, FaTerminal, FaSave } from 'react-icons/fa';
+import { FaPlay, FaRedo, FaChevronRight, FaChevronDown, FaTerminal, FaEye } from 'react-icons/fa';
 import { motion, AnimatePresence } from 'framer-motion';
+import { useNavigate } from 'react-router-dom';
 
 import LanguageSelector from './LanguageSelector';
 
@@ -19,6 +20,7 @@ const defaultCodes = {
 export default function CodeEditor({ initialCode = {}, language = 'html' }) {
     const { theme } = useSelector((state) => state.theme);
     const outputRef = useRef(null);
+    const navigate = useNavigate();
 
     // Consolidated state for all code snippets
     const [codes, setCodes] = useState({
@@ -193,6 +195,25 @@ export default function CodeEditor({ initialCode = {}, language = 'html' }) {
                             <FaRedo className="mr-2 h-4 w-4" /> Reset
                         </Button>
                     </motion.div>
+                    {(selectedLanguage === 'python' || selectedLanguage === 'javascript') && (
+                        <motion.div
+                            whileHover={{ scale: 1.05 }}
+                            whileTap={{ scale: 0.95 }}
+                        >
+                            <Button
+                                outline
+                                gradientDuoTone="purpleToBlue"
+                                onClick={() => navigate('/visualizer', {
+                                    state: {
+                                        code: codes[selectedLanguage],
+                                        language: selectedLanguage,
+                                    }
+                                })}
+                            >
+                                <FaEye className="mr-2 h-4 w-4" /> Visualize
+                            </Button>
+                        </motion.div>
+                    )}
                 </div>
             </div>
             <div className="flex-1 flex flex-col md:flex-row gap-4 overflow-hidden">

--- a/client/src/components/CommandMenu.jsx
+++ b/client/src/components/CommandMenu.jsx
@@ -22,12 +22,14 @@ const CommandMenu = ({ isOpen, onClose }) => {
                 { label: 'Create a Tutorial', path: '/create-tutorial' },
                 { label: 'Create a Quiz', path: '/create-quiz' },
                 { label: 'Create a Page', path: '/create-page' },
+                { label: 'Code Visualizer', path: '/visualizer' },
             ];
         }
 
         return [
             { label: 'Profile', path: '/dashboard?tab=profile' },
             { label: 'Create a Post', path: '/create-post' },
+            { label: 'Code Visualizer', path: '/visualizer' },
         ];
     }, [currentUser]);
 

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -44,6 +44,7 @@ const navLinks = [
   { label: 'Home', path: '/' },
   { label: 'About', path: '/about' },
   { label: 'Projects', path: '/projects' },
+  { label: 'Visualizer', path: '/visualizer' },
 ];
 
 // --- Main Header Component ---

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -15,6 +15,7 @@ import {
     FaRegCreditCard,
     FaThumbtack,
     FaShieldAlt,
+    FaLaptopCode,
 } from 'react-icons/fa';
 import { Avatar, Tooltip, Button } from 'flowbite-react';
 
@@ -211,6 +212,7 @@ const Sidebar = ({ isCollapsed, isPinned, setIsPinned }) => {
         { to: '/tutorials', label: 'Tutorials', icon: FaBook },
         { to: '/quizzes', label: 'Quizzes', icon: FaQuestionCircle },
         { to: '/projects', label: 'Projects', icon: FaProjectDiagram },
+        { to: '/visualizer', label: 'Code Visualizer', icon: FaLaptopCode },
         { to: '/invoices', label: 'Invoices', icon: FaRegFileAlt },
         { to: '/wallet', label: 'Wallet', icon: FaRegCreditCard },
         { to: '/notification', label: 'Notification', icon: FaRegBell },

--- a/client/src/pages/CodeVisualizer.jsx
+++ b/client/src/pages/CodeVisualizer.jsx
@@ -1,0 +1,261 @@
+import React, { useMemo, useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { Button, Card, Select, Textarea, ToggleSwitch, Tooltip, Alert } from 'flowbite-react';
+import { FaExternalLinkAlt, FaInfoCircle, FaPlay, FaRedo, FaLightbulb } from 'react-icons/fa';
+
+const defaultSnippets = {
+    python: `def factorial(n: int) -> int:\n    if n <= 1:\n        return 1\n    return n * factorial(n - 1)\n\nprint('5! =', factorial(5))`,
+    javascript: `function fibonacci(limit) {\n  const seq = [0, 1];\n  while (seq.length < limit) {\n    const next = seq[seq.length - 1] + seq[seq.length - 2];\n    seq.push(next);\n  }\n  return seq;\n}\n\nconsole.log('First 8 numbers:', fibonacci(8));`,
+};
+
+const buildTutorUrl = (language, code, { cumulative, heapPrimitives, textReferences }, mode = 'iframe') => {
+    const params = new URLSearchParams({
+        code,
+        origin: 'scientistshield',
+        cumulative: cumulative ? 'true' : 'false',
+        heapPrimitives: heapPrimitives ? 'true' : 'false',
+        textReferences: textReferences ? 'true' : 'false',
+        curInstr: '0',
+        codeDivHeight: '450',
+        codeDivWidth: '500',
+    });
+
+    if (language === 'python') {
+        params.set('lang', 'python3');
+        params.set('py', '3');
+    } else {
+        params.set('lang', 'js');
+        params.set('js', 'es6');
+    }
+
+    params.set('rawInputLstJSON', '[]');
+
+    const base = mode === 'visualize'
+        ? 'https://pythontutor.com/visualize.html'
+        : 'https://pythontutor.com/iframe-embed.html';
+
+    return `${base}#${params.toString()}`;
+};
+
+const visualizerOptions = [
+    { key: 'cumulative', label: 'Cumulative mode', helper: 'Keeps variables alive between runs (Python only).' },
+    { key: 'heapPrimitives', label: 'Show primitives as references', helper: 'Displays small values on the heap.' },
+    { key: 'textReferences', label: 'Text references', helper: 'Uses textual labels for object references.' },
+];
+
+export default function CodeVisualizer() {
+    const location = useLocation();
+    const incomingLanguage = location.state?.language === 'javascript' ? 'javascript' : 'python';
+    const [language, setLanguage] = useState(incomingLanguage);
+    const [codes, setCodes] = useState({
+        python: incomingLanguage === 'python' && location.state?.code ? location.state.code : defaultSnippets.python,
+        javascript: incomingLanguage === 'javascript' && location.state?.code ? location.state.code : defaultSnippets.javascript,
+    });
+    const [cumulative, setCumulative] = useState(false);
+    const [heapPrimitives, setHeapPrimitives] = useState(false);
+    const [textReferences, setTextReferences] = useState(false);
+    const [visualizerUrl, setVisualizerUrl] = useState(() =>
+        buildTutorUrl(incomingLanguage, incomingLanguage === 'python' ? (location.state?.code || defaultSnippets.python) : (location.state?.code || defaultSnippets.javascript), {
+            cumulative: false,
+            heapPrimitives: false,
+            textReferences: false,
+        })
+    );
+
+    useEffect(() => {
+        if (location.state?.code) {
+            const normalizedLanguage = location.state?.language === 'javascript' ? 'javascript' : 'python';
+            setCodes(prev => ({ ...prev, [normalizedLanguage]: location.state.code }));
+            setLanguage(normalizedLanguage);
+            setCumulative(false);
+            setHeapPrimitives(false);
+            setTextReferences(false);
+            setVisualizerUrl(buildTutorUrl(normalizedLanguage, location.state.code, {
+                cumulative: false,
+                heapPrimitives: false,
+                textReferences: false,
+            }));
+        }
+    }, [location.state?.code, location.state?.language]);
+
+    const supportsCumulative = language === 'python';
+
+    const handleRun = () => {
+        setVisualizerUrl(buildTutorUrl(language, codes[language], {
+            cumulative,
+            heapPrimitives,
+            textReferences,
+        }));
+    };
+
+    const handleReset = () => {
+        setCodes(prev => ({
+            ...prev,
+            [language]: defaultSnippets[language],
+        }));
+        setCumulative(false);
+        setHeapPrimitives(false);
+        setTextReferences(false);
+        setVisualizerUrl(buildTutorUrl(language, defaultSnippets[language], {
+            cumulative: false,
+            heapPrimitives: false,
+            textReferences: false,
+        }));
+    };
+
+    const openInNewTab = () => {
+        const url = buildTutorUrl(language, codes[language], {
+            cumulative,
+            heapPrimitives,
+            textReferences,
+        }, 'visualize');
+        if (typeof window !== 'undefined') {
+            window.open(url, '_blank', 'noopener,noreferrer');
+        }
+    };
+
+    const activeCode = codes[language];
+
+    const infoText = useMemo(() => (
+        language === 'python'
+            ? 'Visualize how each Python line executes, watch stack frames grow, and inspect variables over time.'
+            : 'Step through JavaScript execution to see how the call stack and objects change after each instruction.'
+    ), [language]);
+
+    return (
+        <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-10 px-4 text-gray-800 dark:text-gray-100">
+            <div className="max-w-7xl mx-auto space-y-8">
+                <div className="text-center space-y-3">
+                    <h1 className="text-4xl lg:text-5xl font-extrabold">Code Visualizer</h1>
+                    <p className="text-lg max-w-2xl mx-auto">
+                        Bring your {language === 'python' ? 'Python' : 'JavaScript'} code to life with an execution trace inspired by Python Tutor.
+                        Paste code, tweak the options, and press Visualize to explore each step.
+                    </p>
+                </div>
+
+                <Alert color="info" icon={FaInfoCircle} className="max-w-3xl mx-auto">
+                    <span>
+                        {infoText} This view is powered by an embedded Python Tutor experience.
+                    </span>
+                </Alert>
+
+                <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
+                    <Card className="space-y-6 bg-white/80 dark:bg-gray-800/80 backdrop-blur">
+                        <div className="space-y-3">
+                            <label className="block text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                                Language
+                            </label>
+                            <Select
+                                value={language}
+                                onChange={(event) => {
+                                    const nextLanguage = event.target.value;
+                                    setLanguage(nextLanguage);
+                                    if (nextLanguage !== 'python') {
+                                        setCumulative(false);
+                                    }
+                                    const nextCode = codes[nextLanguage] ?? defaultSnippets[nextLanguage];
+                                    setVisualizerUrl(buildTutorUrl(nextLanguage, nextCode, {
+                                        cumulative: nextLanguage === 'python' ? cumulative : false,
+                                        heapPrimitives,
+                                        textReferences,
+                                    }));
+                                }}
+                            >
+                                <option value="python">Python 3</option>
+                                <option value="javascript">JavaScript (ES6)</option>
+                            </Select>
+                        </div>
+
+                        <div className="space-y-3">
+                            <label className="block text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                                Code
+                            </label>
+                            <Textarea
+                                rows={16}
+                                value={activeCode}
+                                onChange={(event) => setCodes(prev => ({ ...prev, [language]: event.target.value }))}
+                                className="font-mono text-sm"
+                                helperText="Use standard input functions (input()/prompt()) and Python Tutor will prompt during visualization."
+                            />
+                        </div>
+
+                        <div className="space-y-4">
+                            <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                                Visualization options
+                            </h2>
+                            <div className="space-y-3">
+                                {visualizerOptions.map(({ key, label, helper }) => {
+                                    const checked = key === 'cumulative' ? cumulative : key === 'heapPrimitives' ? heapPrimitives : textReferences;
+                                    const setChecked = key === 'cumulative' ? setCumulative : key === 'heapPrimitives' ? setHeapPrimitives : setTextReferences;
+                                    const disabled = key === 'cumulative' && !supportsCumulative;
+                                    const toggle = (
+                                        <ToggleSwitch
+                                            checked={disabled ? false : checked}
+                                            disabled={disabled}
+                                            label={label}
+                                            className="flex w-full flex-row-reverse items-center justify-between"
+                                            aria-label={label}
+                                            onChange={() => setChecked(prev => !prev)}
+                                        />
+                                    );
+
+                                    return (
+                                        <div key={key} className="space-y-1">
+                                            {disabled ? (
+                                                <Tooltip content="Cumulative mode is only available for Python.">{toggle}</Tooltip>
+                                            ) : (
+                                                toggle
+                                            )}
+                                            <p className="text-xs text-gray-500 dark:text-gray-400 pl-1">{helper}</p>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        </div>
+
+                        <div className="flex flex-wrap gap-3">
+                            <Button gradientDuoTone="purpleToBlue" onClick={handleRun}>
+                                <FaPlay className="mr-2" /> Visualize
+                            </Button>
+                            <Button color="gray" onClick={openInNewTab}>
+                                <FaExternalLinkAlt className="mr-2" /> Open full Python Tutor
+                            </Button>
+                            <Button color="light" onClick={handleReset}>
+                                <FaRedo className="mr-2" /> Reset
+                            </Button>
+                        </div>
+
+                        <div className="rounded-lg border border-dashed border-gray-300 dark:border-gray-700 p-4 space-y-2 text-sm">
+                            <div className="flex items-center gap-2 font-semibold">
+                                <FaLightbulb className="text-amber-400" /> Tips
+                            </div>
+                            <ul className="list-disc list-inside space-y-1 text-gray-600 dark:text-gray-300">
+                                <li>Use comments to mark checkpoints before running so you know where to pause.</li>
+                                <li>Switch to cumulative mode to demonstrate how state persists between Python function calls.</li>
+                                <li>Open the full Python Tutor view for sharing or to save a permalink of your trace.</li>
+                            </ul>
+                        </div>
+                    </Card>
+
+                    <Card className="bg-white/80 dark:bg-gray-800/80 backdrop-blur min-h-[550px] flex flex-col">
+                        <div className="flex items-center justify-between mb-4">
+                            <h2 className="text-lg font-semibold">Execution trace</h2>
+                            <Button size="xs" color="gray" onClick={handleRun}>
+                                <FaPlay className="mr-1" /> Refresh
+                            </Button>
+                        </div>
+                        <div className="flex-1 rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
+                            <iframe
+                                key={visualizerUrl}
+                                title="Python Tutor Visualizer"
+                                src={visualizerUrl}
+                                className="w-full h-[500px] md:h-full"
+                                allowFullScreen
+                            />
+                        </div>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/client/src/pages/TryItPage.jsx
+++ b/client/src/pages/TryItPage.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import CodeEditor from '../components/CodeEditor';
 import { Alert, Button } from 'flowbite-react';
-import { FaExternalLinkAlt } from 'react-icons/fa';
+import { FaExternalLinkAlt, FaLaptopCode } from 'react-icons/fa';
 
 export default function TryItPage() {
     const location = useLocation();
@@ -47,6 +47,16 @@ export default function TryItPage() {
                     initialCode={editorCode}
                     language={editorLanguage}
                 />
+
+                <Alert color="purple" className="mt-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                    <div className="flex items-center gap-3 text-sm sm:text-base">
+                        <FaLaptopCode className="text-xl" />
+                        <span>Need to walk through execution line-by-line? Open the interactive Code Visualizer.</span>
+                    </div>
+                    <Button gradientDuoTone="purpleToBlue" as={Link} to="/visualizer">
+                        <FaExternalLinkAlt className="mr-2" /> Launch Visualizer
+                    </Button>
+                </Alert>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- add a dedicated Code Visualizer page that embeds Python Tutor and supports Python/JavaScript traces
- expose the visualizer throughout the UI with navigation links, command menu shortcuts, and a CTA from the Try It editor
- enhance the shared code editor with a Visualize button that deep-links the current snippet into the new tool

## Testing
- npm run build --prefix client *(fails: missing external dependency `immer` in the environment)*
- npm run lint --prefix client *(fails: existing lint issues across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68cc1c820808832da034cb96d4afdc91