### PR TITLE
Add Python execution visualizer

### DIFF
--- a/api/routes/python.route.js
+++ b/api/routes/python.route.js
@@ -1,8 +1,9 @@
 import express from 'express';
-import { runPythonCode } from '../controllers/python.controller.js';
+import { runPythonCode, visualizePythonCode } from '../controllers/python.controller.js';
 
 const router = express.Router();
 
 router.post('/run-python', runPythonCode);
+router.post('/visualize-python', visualizePythonCode);
 
 export default router;

--- a/api/utils/python_visualizer.py
+++ b/api/utils/python_visualizer.py
@@ -1,0 +1,131 @@
+
+import contextlib
+import io
+import json
+import sys
+import traceback
+from types import FrameType
+from typing import Any, Dict, List
+
+
+def safe_repr(value: Any, max_length: int = 120) -> str:
+    """Return a human-friendly representation of a Python value."""
+    try:
+        result = repr(value)
+    except Exception:  # pragma: no cover - repr failures are rare and best-effort
+        result = f"<unrepresentable {type(value).__name__}>"
+    if len(result) > max_length:
+        result = result[: max_length - 3] + "..."
+    return result
+
+
+def build_stack(frame: FrameType, user_filename: str) -> List[Dict[str, Any]]:
+    """Create a simplified representation of the active call stack."""
+    stack: List[Dict[str, Any]] = []
+    seen = 0
+    while frame is not None and seen < 32:
+        code = frame.f_code
+        if code.co_filename == user_filename:
+            stack.append(
+                {
+                    "function": code.co_name or "<module>",
+                    "line": frame.f_lineno,
+                }
+            )
+        frame = frame.f_back
+        seen += 1
+    stack.reverse()
+    return stack
+
+
+def tracer_factory(events: List[Dict[str, Any]], stdout_buffer: io.StringIO, user_filename: str):
+    """Create a tracing function that records execution events."""
+
+    def _tracer(frame: FrameType, event: str, arg: Any):
+        if frame.f_code.co_filename != user_filename:
+            return _tracer
+
+        if event not in ("call", "line", "return", "exception"):
+            return _tracer
+
+        entry: Dict[str, Any] = {
+            "event": event,
+            "line": frame.f_lineno,
+            "function": frame.f_code.co_name or "<module>",
+            "locals": {
+                name: safe_repr(value)
+                for name, value in frame.f_locals.items()
+                if not name.startswith("__") and name != "self"
+            },
+            "stack": build_stack(frame, user_filename),
+            "stdout": stdout_buffer.getvalue(),
+        }
+
+        if event == "return":
+            entry["returnValue"] = safe_repr(arg)
+        elif event == "exception" and isinstance(arg, tuple) and len(arg) >= 2:
+            exc_type, exc_value = arg[:2]
+            entry["exception"] = {
+                "type": getattr(exc_type, "__name__", str(exc_type)),
+                "message": safe_repr(exc_value),
+            }
+
+        events.append(entry)
+        return _tracer
+
+    return _tracer
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(json.dumps({"success": False, "error": "Expected a single argument with the path to the code file."}))
+        return
+
+    code_path = sys.argv[1]
+    events: List[Dict[str, Any]] = []
+    stdout_buffer = io.StringIO()
+    stderr_buffer = io.StringIO()
+
+    try:
+        with open(code_path, "r", encoding="utf-8") as handle:
+            source = handle.read()
+
+        compiled = compile(source, code_path, "exec")
+        global_namespace: Dict[str, Any] = {
+            "__name__": "__main__",
+            "__file__": code_path,
+            "__package__": None,
+        }
+
+        sys.settrace(tracer_factory(events, stdout_buffer, code_path))
+        try:
+            with contextlib.redirect_stdout(stdout_buffer), contextlib.redirect_stderr(stderr_buffer):
+                exec(compiled, global_namespace, global_namespace)
+        finally:
+            sys.settrace(None)
+
+    except Exception as exc:  # pragma: no cover - execution errors are data we want to return
+        tb = traceback.format_exc()
+        result = {
+            "success": False,
+            "events": events,
+            "stdout": stdout_buffer.getvalue(),
+            "stderr": stderr_buffer.getvalue(),
+            "error": {
+                "message": str(exc),
+                "traceback": tb,
+            },
+        }
+    else:
+        result = {
+            "success": True,
+            "events": events,
+            "stdout": stdout_buffer.getvalue(),
+            "stderr": stderr_buffer.getvalue(),
+        }
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/client/src/components/BottomNav.jsx
+++ b/client/src/components/BottomNav.jsx
@@ -9,7 +9,7 @@ const items = [
     { to: '/', label: 'Home', icon: FaHome },
     { to: '/tutorials', label: 'Tutorials', icon: FaBook },
     { to: '/quizzes', label: 'Quizzes', icon: FaQuestionCircle },
-    { to: '/visualizer', label: 'Visualizer', icon: FaLaptopCode }
+    { to: '/visualizer', label: 'Python Visualizer', icon: FaLaptopCode }
 ];
 
 export default function BottomNav() {

--- a/client/src/components/CodeEditor.jsx
+++ b/client/src/components/CodeEditor.jsx
@@ -195,7 +195,7 @@ export default function CodeEditor({ initialCode = {}, language = 'html' }) {
                             <FaRedo className="mr-2 h-4 w-4" /> Reset
                         </Button>
                     </motion.div>
-                    {(selectedLanguage === 'python' || selectedLanguage === 'javascript') && (
+                    {selectedLanguage === 'python' && (
                         <motion.div
                             whileHover={{ scale: 1.05 }}
                             whileTap={{ scale: 0.95 }}

--- a/client/src/components/CommandMenu.jsx
+++ b/client/src/components/CommandMenu.jsx
@@ -22,14 +22,14 @@ const CommandMenu = ({ isOpen, onClose }) => {
                 { label: 'Create a Tutorial', path: '/create-tutorial' },
                 { label: 'Create a Quiz', path: '/create-quiz' },
                 { label: 'Create a Page', path: '/create-page' },
-                { label: 'Code Visualizer', path: '/visualizer' },
+                { label: 'Python Visualizer', path: '/visualizer' },
             ];
         }
 
         return [
             { label: 'Profile', path: '/dashboard?tab=profile' },
             { label: 'Create a Post', path: '/create-post' },
-            { label: 'Code Visualizer', path: '/visualizer' },
+            { label: 'Python Visualizer', path: '/visualizer' },
         ];
     }, [currentUser]);
 

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -44,7 +44,7 @@ const navLinks = [
   { label: 'Home', path: '/' },
   { label: 'About', path: '/about' },
   { label: 'Projects', path: '/projects' },
-  { label: 'Visualizer', path: '/visualizer' },
+  { label: 'Python Visualizer', path: '/visualizer' },
 ];
 
 // --- Main Header Component ---

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -212,7 +212,7 @@ const Sidebar = ({ isCollapsed, isPinned, setIsPinned }) => {
         { to: '/tutorials', label: 'Tutorials', icon: FaBook },
         { to: '/quizzes', label: 'Quizzes', icon: FaQuestionCircle },
         { to: '/projects', label: 'Projects', icon: FaProjectDiagram },
-        { to: '/visualizer', label: 'Code Visualizer', icon: FaLaptopCode },
+        { to: '/visualizer', label: 'Python Visualizer', icon: FaLaptopCode },
         { to: '/invoices', label: 'Invoices', icon: FaRegFileAlt },
         { to: '/wallet', label: 'Wallet', icon: FaRegCreditCard },
         { to: '/notification', label: 'Notification', icon: FaRegBell },

--- a/client/src/pages/CodeVisualizer.jsx
+++ b/client/src/pages/CodeVisualizer.jsx
@@ -1,257 +1,478 @@
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { Button, Card, Select, Textarea, ToggleSwitch, Tooltip, Alert } from 'flowbite-react';
-import { FaExternalLinkAlt, FaInfoCircle, FaPlay, FaRedo, FaLightbulb } from 'react-icons/fa';
+import {
+    Alert,
+    Badge,
+    Button,
+    Card,
+    Spinner,
+    Textarea,
+    ToggleSwitch,
+    Tooltip,
+} from 'flowbite-react';
+import {
+    FaBug,
+    FaCode,
+    FaInfoCircle,
+    FaPause,
+    FaPlay,
+    FaRedo,
+    FaStepBackward,
+    FaStepForward,
+    FaTerminal,
+} from 'react-icons/fa';
 
-const defaultSnippets = {
-    python: `def factorial(n: int) -> int:\n    if n <= 1:\n        return 1\n    return n * factorial(n - 1)\n\nprint('5! =', factorial(5))`,
-    javascript: `function fibonacci(limit) {\n  const seq = [0, 1];\n  while (seq.length < limit) {\n    const next = seq[seq.length - 1] + seq[seq.length - 2];\n    seq.push(next);\n  }\n  return seq;\n}\n\nconsole.log('First 8 numbers:', fibonacci(8));`,
+const defaultPythonSnippet = `def factorial(n: int) -> int:\n    if n <= 1:\n        return 1\n    return n * factorial(n - 1)\n\nprint('5! =', factorial(5))`;
+
+const eventMetadata = {
+    call: { label: 'Call', color: 'purple' },
+    line: { label: 'Line', color: 'info' },
+    return: { label: 'Return', color: 'success' },
+    exception: { label: 'Exception', color: 'failure' },
 };
 
-const buildTutorUrl = (language, code, { cumulative, heapPrimitives, textReferences }, mode = 'iframe') => {
-    const params = new URLSearchParams({
-        code,
-        origin: 'scientistshield',
-        cumulative: cumulative ? 'true' : 'false',
-        heapPrimitives: heapPrimitives ? 'true' : 'false',
-        textReferences: textReferences ? 'true' : 'false',
-        curInstr: '0',
-        codeDivHeight: '450',
-        codeDivWidth: '500',
-    });
-
-    if (language === 'python') {
-        params.set('lang', 'python3');
-        params.set('py', '3');
-    } else {
-        params.set('lang', 'js');
-        params.set('js', 'es6');
-    }
-
-    params.set('rawInputLstJSON', '[]');
-
-    const base = mode === 'visualize'
-        ? 'https://pythontutor.com/visualize.html'
-        : 'https://pythontutor.com/iframe-embed.html';
-
-    return `${base}#${params.toString()}`;
+const descriptiveLabels = {
+    call: 'A function frame was pushed onto the stack.',
+    line: 'A line of code executed inside the current frame.',
+    return: 'Execution is returning from the current frame.',
+    exception: 'An exception was raised at this position.',
 };
 
-const visualizerOptions = [
-    { key: 'cumulative', label: 'Cumulative mode', helper: 'Keeps variables alive between runs (Python only).' },
-    { key: 'heapPrimitives', label: 'Show primitives as references', helper: 'Displays small values on the heap.' },
-    { key: 'textReferences', label: 'Text references', helper: 'Uses textual labels for object references.' },
-];
+const formatStepLabel = (event) => {
+    const meta = eventMetadata[event.event] ?? { label: 'Event' };
+    return meta.label;
+};
 
 export default function CodeVisualizer() {
     const location = useLocation();
-    const incomingLanguage = location.state?.language === 'javascript' ? 'javascript' : 'python';
-    const [language, setLanguage] = useState(incomingLanguage);
-    const [codes, setCodes] = useState({
-        python: incomingLanguage === 'python' && location.state?.code ? location.state.code : defaultSnippets.python,
-        javascript: incomingLanguage === 'javascript' && location.state?.code ? location.state.code : defaultSnippets.javascript,
-    });
-    const [cumulative, setCumulative] = useState(false);
-    const [heapPrimitives, setHeapPrimitives] = useState(false);
-    const [textReferences, setTextReferences] = useState(false);
-    const [visualizerUrl, setVisualizerUrl] = useState(() =>
-        buildTutorUrl(incomingLanguage, incomingLanguage === 'python' ? (location.state?.code || defaultSnippets.python) : (location.state?.code || defaultSnippets.javascript), {
-            cumulative: false,
-            heapPrimitives: false,
-            textReferences: false,
-        })
-    );
+    const incomingPythonCode =
+        location.state?.language === 'python' && typeof location.state?.code === 'string'
+            ? location.state.code
+            : null;
+
+    const [code, setCode] = useState(incomingPythonCode || defaultPythonSnippet);
+    const [trace, setTrace] = useState(null);
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const [isPlaying, setIsPlaying] = useState(false);
+    const [playDelay, setPlayDelay] = useState(900);
+    const [autoPlay, setAutoPlay] = useState(true);
+    const [isLoading, setIsLoading] = useState(false);
+    const [errorMessage, setErrorMessage] = useState(null);
+
+    const events = trace?.events ?? [];
+    const hasEvents = events.length > 0;
+    const currentEvent = hasEvents ? events[Math.min(currentIndex, events.length - 1)] : null;
+    const codeLines = useMemo(() => code.replace(/\r\n/g, '\n').split('\n'), [code]);
+    const currentLine = currentEvent?.line ?? null;
 
     useEffect(() => {
-        if (location.state?.code) {
-            const normalizedLanguage = location.state?.language === 'javascript' ? 'javascript' : 'python';
-            setCodes(prev => ({ ...prev, [normalizedLanguage]: location.state.code }));
-            setLanguage(normalizedLanguage);
-            setCumulative(false);
-            setHeapPrimitives(false);
-            setTextReferences(false);
-            setVisualizerUrl(buildTutorUrl(normalizedLanguage, location.state.code, {
-                cumulative: false,
-                heapPrimitives: false,
-                textReferences: false,
-            }));
+        if (!isPlaying) return undefined;
+        if (!hasEvents) return undefined;
+        if (currentIndex >= events.length - 1) {
+            setIsPlaying(false);
+            return undefined;
         }
-    }, [location.state?.code, location.state?.language]);
 
-    const supportsCumulative = language === 'python';
+        const timer = setTimeout(() => {
+            setCurrentIndex((previous) => Math.min(previous + 1, events.length - 1));
+        }, playDelay);
 
-    const handleRun = () => {
-        setVisualizerUrl(buildTutorUrl(language, codes[language], {
-            cumulative,
-            heapPrimitives,
-            textReferences,
-        }));
-    };
+        return () => clearTimeout(timer);
+    }, [isPlaying, playDelay, currentIndex, events.length, hasEvents]);
 
-    const handleReset = () => {
-        setCodes(prev => ({
-            ...prev,
-            [language]: defaultSnippets[language],
-        }));
-        setCumulative(false);
-        setHeapPrimitives(false);
-        setTextReferences(false);
-        setVisualizerUrl(buildTutorUrl(language, defaultSnippets[language], {
-            cumulative: false,
-            heapPrimitives: false,
-            textReferences: false,
-        }));
-    };
+    useEffect(() => {
+        if (incomingPythonCode) {
+            setCode(incomingPythonCode);
+        }
+    }, [incomingPythonCode]);
 
-    const openInNewTab = () => {
-        const url = buildTutorUrl(language, codes[language], {
-            cumulative,
-            heapPrimitives,
-            textReferences,
-        }, 'visualize');
-        if (typeof window !== 'undefined') {
-            window.open(url, '_blank', 'noopener,noreferrer');
+    const handleVisualize = async () => {
+        setIsLoading(true);
+        setIsPlaying(false);
+        setErrorMessage(null);
+
+        try {
+            const response = await fetch('/api/code/visualize-python', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ code }),
+            });
+
+            const payload = await response.json();
+
+            if (!response.ok) {
+                setTrace(null);
+                setErrorMessage(payload?.message || 'Unable to visualize the code.');
+                return;
+            }
+
+            setTrace(payload);
+            setCurrentIndex(0);
+            if (payload?.error?.message) {
+                setErrorMessage(payload.error.message);
+            } else if (!payload.success) {
+                setErrorMessage('Visualization completed with errors. Inspect the trace for details.');
+            } else {
+                setErrorMessage(null);
+            }
+
+            if (autoPlay && Array.isArray(payload?.events) && payload.events.length > 0) {
+                setIsPlaying(true);
+            }
+        } catch (error) {
+            console.error('Failed to visualize python code:', error);
+            setTrace(null);
+            setErrorMessage('An unexpected error occurred while visualizing your code.');
+        } finally {
+            setIsLoading(false);
         }
     };
 
-    const activeCode = codes[language];
+    const handleResetCode = () => {
+        setCode(defaultPythonSnippet);
+        setTrace(null);
+        setCurrentIndex(0);
+        setIsPlaying(false);
+        setErrorMessage(null);
+    };
 
-    const infoText = useMemo(() => (
-        language === 'python'
-            ? 'Visualize how each Python line executes, watch stack frames grow, and inspect variables over time.'
-            : 'Step through JavaScript execution to see how the call stack and objects change after each instruction.'
-    ), [language]);
+    const goToStep = (index) => {
+        if (!hasEvents) return;
+        setCurrentIndex(Math.max(0, Math.min(index, events.length - 1)));
+        setIsPlaying(false);
+    };
+
+    const handleStepForward = () => {
+        if (!hasEvents) return;
+        goToStep(Math.min(currentIndex + 1, events.length - 1));
+    };
+
+    const handleStepBackward = () => {
+        if (!hasEvents) return;
+        goToStep(Math.max(currentIndex - 1, 0));
+    };
+
+    const togglePlayback = () => {
+        if (!hasEvents) return;
+        setIsPlaying((prev) => !prev);
+    };
+
+    const stdoutForCurrentStep = currentEvent?.stdout ?? trace?.stdout ?? '';
+    const stderrOutput = trace?.stderr ?? '';
+    const activeEventMeta = currentEvent ? eventMetadata[currentEvent.event] : null;
 
     return (
-        <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-10 px-4 text-gray-800 dark:text-gray-100">
+        <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-10 px-4 text-gray-900 dark:text-gray-100">
             <div className="max-w-7xl mx-auto space-y-8">
-                <div className="text-center space-y-3">
-                    <h1 className="text-4xl lg:text-5xl font-extrabold">Code Visualizer</h1>
-                    <p className="text-lg max-w-2xl mx-auto">
-                        Bring your {language === 'python' ? 'Python' : 'JavaScript'} code to life with an execution trace inspired by Python Tutor.
-                        Paste code, tweak the options, and press Visualize to explore each step.
+                <div className="space-y-3 text-center">
+                    <h1 className="text-4xl lg:text-5xl font-extrabold">Python Execution Visualizer</h1>
+                    <p className="text-lg max-w-3xl mx-auto text-gray-600 dark:text-gray-300">
+                        Step through your Python code line by line. Watch the call stack evolve, inspect variable state, and
+                        capture console output without leaving ScientistShield.
                     </p>
                 </div>
 
                 <Alert color="info" icon={FaInfoCircle} className="max-w-3xl mx-auto">
-                    <span>
-                        {infoText} This view is powered by an embedded Python Tutor experience.
-                    </span>
+                    Paste Python 3 code, press <strong>Visualize</strong>, and then walk through the execution timeline using
+                    the playback controls. Each step includes the active line, variable snapshots, and the call stack.
                 </Alert>
 
-                <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
-                    <Card className="space-y-6 bg-white/80 dark:bg-gray-800/80 backdrop-blur">
-                        <div className="space-y-3">
-                            <label className="block text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                                Language
-                            </label>
-                            <Select
-                                value={language}
-                                onChange={(event) => {
-                                    const nextLanguage = event.target.value;
-                                    setLanguage(nextLanguage);
-                                    if (nextLanguage !== 'python') {
-                                        setCumulative(false);
-                                    }
-                                    const nextCode = codes[nextLanguage] ?? defaultSnippets[nextLanguage];
-                                    setVisualizerUrl(buildTutorUrl(nextLanguage, nextCode, {
-                                        cumulative: nextLanguage === 'python' ? cumulative : false,
-                                        heapPrimitives,
-                                        textReferences,
-                                    }));
-                                }}
-                            >
-                                <option value="python">Python 3</option>
-                                <option value="javascript">JavaScript (ES6)</option>
-                            </Select>
-                        </div>
+                <Card className="space-y-6 bg-white/90 dark:bg-gray-800/80 backdrop-blur">
+                    <div className="flex flex-col lg:flex-row lg:items-start gap-6">
+                        <div className="flex-1 space-y-4">
+                            <div className="space-y-2">
+                                <label className="block text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                                    Python code
+                                </label>
+                                <Textarea
+                                    rows={16}
+                                    value={code}
+                                    onChange={(event) => setCode(event.target.value)}
+                                    className="font-mono text-sm"
+                                    helperText="The visualizer captures standard output, return values, and exceptions."
+                                />
+                            </div>
 
-                        <div className="space-y-3">
-                            <label className="block text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                                Code
-                            </label>
-                            <Textarea
-                                rows={16}
-                                value={activeCode}
-                                onChange={(event) => setCodes(prev => ({ ...prev, [language]: event.target.value }))}
-                                className="font-mono text-sm"
-                                helperText="Use standard input functions (input()/prompt()) and Python Tutor will prompt during visualization."
-                            />
-                        </div>
-
-                        <div className="space-y-4">
-                            <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                                Visualization options
-                            </h2>
-                            <div className="space-y-3">
-                                {visualizerOptions.map(({ key, label, helper }) => {
-                                    const checked = key === 'cumulative' ? cumulative : key === 'heapPrimitives' ? heapPrimitives : textReferences;
-                                    const setChecked = key === 'cumulative' ? setCumulative : key === 'heapPrimitives' ? setHeapPrimitives : setTextReferences;
-                                    const disabled = key === 'cumulative' && !supportsCumulative;
-                                    const toggle = (
-                                        <ToggleSwitch
-                                            checked={disabled ? false : checked}
-                                            disabled={disabled}
-                                            label={label}
-                                            className="flex w-full flex-row-reverse items-center justify-between"
-                                            aria-label={label}
-                                            onChange={() => setChecked(prev => !prev)}
+                            <div className="flex flex-wrap items-center gap-3">
+                                <Button gradientDuoTone="purpleToBlue" onClick={handleVisualize} disabled={isLoading}>
+                                    {isLoading ? (
+                                        <>
+                                            <Spinner size="sm" className="mr-2" />
+                                            Visualizing...
+                                        </>
+                                    ) : (
+                                        <>
+                                            <FaPlay className="mr-2" /> Visualize
+                                        </>
+                                    )}
+                                </Button>
+                                <Button color="light" onClick={handleResetCode} disabled={isLoading}>
+                                    <FaRedo className="mr-2" /> Reset to example
+                                </Button>
+                                <ToggleSwitch
+                                    checked={autoPlay}
+                                    label="Auto-play after run"
+                                    onChange={() => setAutoPlay((prev) => !prev)}
+                                />
+                                <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+                                    <span>Step delay:</span>
+                                    <Tooltip content={`${(playDelay / 1000).toFixed(1)}s per step`}>
+                                        <input
+                                            type="range"
+                                            min={300}
+                                            max={2000}
+                                            step={100}
+                                            value={playDelay}
+                                            onChange={(event) => setPlayDelay(Number(event.target.value))}
+                                            className="w-36 accent-purple-500"
                                         />
-                                    );
+                                    </Tooltip>
+                                </div>
+                            </div>
+                        </div>
 
+                        <div className="w-full lg:w-80 space-y-4">
+                            <Card className="bg-purple-500/10 border border-purple-200 dark:border-purple-700">
+                                <div className="flex items-center gap-3">
+                                    <FaCode className="text-purple-500" />
+                                    <div>
+                                        <h2 className="text-sm font-semibold">How it works</h2>
+                                        <p className="text-xs text-gray-600 dark:text-gray-300">
+                                            We execute your Python code in an isolated worker with tracing enabled, capturing every
+                                            call, line, return, and exception. Nothing is stored on the server.
+                                        </p>
+                                    </div>
+                                </div>
+                            </Card>
+
+                            <Card className="bg-amber-500/10 border border-amber-200 dark:border-amber-700">
+                                <div className="flex items-start gap-3">
+                                    <FaBug className="text-amber-500 mt-1" />
+                                    <div>
+                                        <h2 className="text-sm font-semibold">Tips</h2>
+                                        <ul className="list-disc list-inside text-xs text-gray-600 dark:text-gray-300 space-y-1">
+                                            <li>Add print statements to compare console output with variable snapshots.</li>
+                                            <li>Recursive functions shine when you track the stack growth step-by-step.</li>
+                                            <li>Use the slider to slow down tricky sections of code.</li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </Card>
+                        </div>
+                    </div>
+                </Card>
+
+                {errorMessage && (
+                    <Alert color="failure" icon={FaBug} className="max-w-4xl mx-auto">
+                        {errorMessage}
+                    </Alert>
+                )}
+
+                <div className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+                    <Card className="space-y-5 bg-white/90 dark:bg-gray-800/80 backdrop-blur">
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                            <div>
+                                <h2 className="text-lg font-semibold flex items-center gap-2">
+                                    <FaCode /> Trace timeline
+                                </h2>
+                                <p className="text-sm text-gray-500 dark:text-gray-400">
+                                    {hasEvents
+                                        ? `Step ${currentIndex + 1} of ${events.length}`
+                                        : 'Run the visualizer to generate an execution trace.'}
+                                </p>
+                            </div>
+                            <div className="flex flex-wrap items-center gap-2">
+                                <Button color="light" onClick={handleStepBackward} disabled={!hasEvents}>
+                                    <FaStepBackward className="mr-1" /> Prev
+                                </Button>
+                                <Button color="light" onClick={togglePlayback} disabled={!hasEvents}>
+                                    {isPlaying ? (
+                                        <>
+                                            <FaPause className="mr-1" /> Pause
+                                        </>
+                                    ) : (
+                                        <>
+                                            <FaPlay className="mr-1" /> Play
+                                        </>
+                                    )}
+                                </Button>
+                                <Button color="light" onClick={handleStepForward} disabled={!hasEvents}>
+                                    <FaStepForward className="mr-1" /> Next
+                                </Button>
+                                <Button color="light" onClick={() => goToStep(0)} disabled={!hasEvents}>
+                                    <FaRedo className="mr-1" /> Restart
+                                </Button>
+                            </div>
+                        </div>
+
+                        <div className="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+                            <pre className="bg-gray-900 text-gray-100 text-sm font-mono p-4 overflow-auto max-h-[420px]">
+                                {codeLines.map((line, index) => {
+                                    const isActive = currentLine === index + 1;
                                     return (
-                                        <div key={key} className="space-y-1">
-                                            {disabled ? (
-                                                <Tooltip content="Cumulative mode is only available for Python.">{toggle}</Tooltip>
-                                            ) : (
-                                                toggle
-                                            )}
-                                            <p className="text-xs text-gray-500 dark:text-gray-400 pl-1">{helper}</p>
+                                        <div
+                                            key={index}
+                                            className={`flex items-start gap-4 py-1 px-2 rounded ${
+                                                isActive ? 'bg-purple-500/30 text-white' : 'text-gray-300'
+                                            }`}
+                                        >
+                                            <span className="w-10 text-right text-xs text-gray-500 dark:text-gray-500">
+                                                {index + 1}
+                                            </span>
+                                            <span className="flex-1 whitespace-pre">{line || ' '}</span>
                                         </div>
                                     );
                                 })}
-                            </div>
+                            </pre>
                         </div>
 
-                        <div className="flex flex-wrap gap-3">
-                            <Button gradientDuoTone="purpleToBlue" onClick={handleRun}>
-                                <FaPlay className="mr-2" /> Visualize
-                            </Button>
-                            <Button color="gray" onClick={openInNewTab}>
-                                <FaExternalLinkAlt className="mr-2" /> Open full Python Tutor
-                            </Button>
-                            <Button color="light" onClick={handleReset}>
-                                <FaRedo className="mr-2" /> Reset
-                            </Button>
-                        </div>
-
-                        <div className="rounded-lg border border-dashed border-gray-300 dark:border-gray-700 p-4 space-y-2 text-sm">
-                            <div className="flex items-center gap-2 font-semibold">
-                                <FaLightbulb className="text-amber-400" /> Tips
-                            </div>
-                            <ul className="list-disc list-inside space-y-1 text-gray-600 dark:text-gray-300">
-                                <li>Use comments to mark checkpoints before running so you know where to pause.</li>
-                                <li>Switch to cumulative mode to demonstrate how state persists between Python function calls.</li>
-                                <li>Open the full Python Tutor view for sharing or to save a permalink of your trace.</li>
-                            </ul>
+                        <div className="space-y-2">
+                            <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                                Timeline
+                            </h3>
+                            {hasEvents ? (
+                                <div className="flex overflow-x-auto gap-3 pb-1">
+                                    {events.map((event, index) => {
+                                        const isActive = index === currentIndex;
+                                        const meta = eventMetadata[event.event] ?? { color: 'gray', label: 'Event' };
+                                        return (
+                                            <Tooltip
+                                                key={`event-${index}`}
+                                                content={`${formatStepLabel(event)} — ${descriptiveLabels[event.event] || ''}`}
+                                            >
+                                                <button
+                                                    type="button"
+                                                    onClick={() => goToStep(index)}
+                                                    className={`flex flex-col items-center justify-center px-3 py-2 rounded-lg border text-xs font-semibold transition focus:outline-none focus:ring-2 focus:ring-purple-400 ${
+                                                        isActive
+                                                            ? 'bg-purple-600 text-white border-purple-600 shadow-lg'
+                                                            : 'bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:border-purple-400'
+                                                    }`}
+                                                >
+                                                    <span className="text-[0.7rem] uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                                                        #{index + 1}
+                                                    </span>
+                                                    <span>{meta.label}</span>
+                                                </button>
+                                            </Tooltip>
+                                        );
+                                    })}
+                                </div>
+                            ) : (
+                                <p className="text-sm text-gray-500 dark:text-gray-400">
+                                    Once a trace is generated, each event will appear here for quick navigation.
+                                </p>
+                            )}
                         </div>
                     </Card>
 
-                    <Card className="bg-white/80 dark:bg-gray-800/80 backdrop-blur min-h-[550px] flex flex-col">
-                        <div className="flex items-center justify-between mb-4">
-                            <h2 className="text-lg font-semibold">Execution trace</h2>
-                            <Button size="xs" color="gray" onClick={handleRun}>
-                                <FaPlay className="mr-1" /> Refresh
-                            </Button>
+                    <Card className="space-y-5 bg-white/90 dark:bg-gray-800/80 backdrop-blur">
+                        <div className="flex items-center justify-between">
+                            <h2 className="text-lg font-semibold flex items-center gap-2">
+                                <FaTerminal /> State inspector
+                            </h2>
+                            {activeEventMeta && (
+                                <Badge color={activeEventMeta.color} className="uppercase">
+                                    {activeEventMeta.label}
+                                </Badge>
+                            )}
                         </div>
-                        <div className="flex-1 rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
-                            <iframe
-                                key={visualizerUrl}
-                                title="Python Tutor Visualizer"
-                                src={visualizerUrl}
-                                className="w-full h-[500px] md:h-full"
-                                allowFullScreen
-                            />
+
+                        {currentEvent ? (
+                            <div className="space-y-4">
+                                <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-white dark:bg-gray-900">
+                                    <h3 className="text-sm font-semibold text-gray-600 dark:text-gray-300">Event details</h3>
+                                    <dl className="mt-2 space-y-1 text-sm text-gray-600 dark:text-gray-300">
+                                        <div className="flex justify-between">
+                                            <dt>Function</dt>
+                                            <dd className="font-mono">{currentEvent.function}</dd>
+                                        </div>
+                                        <div className="flex justify-between">
+                                            <dt>Line</dt>
+                                            <dd className="font-mono">{currentEvent.line}</dd>
+                                        </div>
+                                        {currentEvent.event === 'return' && currentEvent.returnValue && (
+                                            <div className="flex justify-between">
+                                                <dt>Return value</dt>
+                                                <dd className="font-mono">{currentEvent.returnValue}</dd>
+                                            </div>
+                                        )}
+                                        {currentEvent.event === 'exception' && currentEvent.exception && (
+                                            <div className="text-red-500 dark:text-red-400">
+                                                <p className="font-semibold">{currentEvent.exception.type}</p>
+                                                <p className="font-mono text-xs">{currentEvent.exception.message}</p>
+                                            </div>
+                                        )}
+                                        <div className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+                                            {descriptiveLabels[currentEvent.event]}
+                                        </div>
+                                    </dl>
+                                </div>
+
+                                <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-white dark:bg-gray-900">
+                                    <h3 className="text-sm font-semibold text-gray-600 dark:text-gray-300">Local variables</h3>
+                                    {currentEvent.locals && Object.keys(currentEvent.locals).length > 0 ? (
+                                        <ul className="mt-2 space-y-1 text-sm font-mono text-gray-700 dark:text-gray-200">
+                                            {Object.entries(currentEvent.locals).map(([key, value]) => (
+                                                <li key={key} className="flex justify-between gap-3">
+                                                    <span className="text-purple-500">{key}</span>
+                                                    <span className="text-right break-all">{value}</span>
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    ) : (
+                                        <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">No locals captured for this step.</p>
+                                    )}
+                                </div>
+
+                                <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-white dark:bg-gray-900">
+                                    <h3 className="text-sm font-semibold text-gray-600 dark:text-gray-300">Call stack</h3>
+                                    {currentEvent.stack && currentEvent.stack.length > 0 ? (
+                                        <ol className="mt-2 space-y-1 text-sm text-gray-700 dark:text-gray-200">
+                                            {currentEvent.stack.map((frame, index) => (
+                                                <li key={`${frame.function}-${index}`} className="flex justify-between">
+                                                    <span>{frame.function}</span>
+                                                    <span className="font-mono text-xs text-gray-500">line {frame.line}</span>
+                                                </li>
+                                            ))}
+                                        </ol>
+                                    ) : (
+                                        <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">Stack is empty at this step.</p>
+                                    )}
+                                </div>
+                            </div>
+                        ) : (
+                            <div className="text-sm text-gray-500 dark:text-gray-400">
+                                Generate a trace to inspect execution state. Variable snapshots, return values, and exceptions
+                                will appear here as you step through the timeline.
+                            </div>
+                        )}
+
+                        <div className="rounded-lg border border-dashed border-gray-300 dark:border-gray-700 p-4 space-y-3">
+                            <div className="flex items-center gap-2 text-sm font-semibold">
+                                <FaTerminal /> Console output
+                            </div>
+                            <pre className="bg-gray-900 text-green-300 text-sm font-mono p-3 rounded-lg min-h-[100px] overflow-auto">
+                                {stdoutForCurrentStep ? stdoutForCurrentStep : 'No output captured yet.'}
+                            </pre>
+                            {stderrOutput && (
+                                <Alert color="warning" className="bg-amber-500/10 border border-amber-200 dark:border-amber-600">
+                                    <span className="font-semibold">stderr</span>
+                                    <pre className="mt-1 text-xs font-mono whitespace-pre-wrap text-amber-600 dark:text-amber-300">
+                                        {stderrOutput}
+                                    </pre>
+                                </Alert>
+                            )}
+                            {trace?.error?.traceback && (
+                                <Alert color="failure" className="bg-red-500/10 border border-red-300 dark:border-red-600">
+                                    <span className="font-semibold">Python traceback</span>
+                                    <pre className="mt-2 text-xs font-mono whitespace-pre-wrap text-red-500 dark:text-red-300">
+                                        {trace.error.traceback}
+                                    </pre>
+                                </Alert>
+                            )}
                         </div>
                     </Card>
                 </div>

--- a/client/src/pages/TryItPage.jsx
+++ b/client/src/pages/TryItPage.jsx
@@ -51,7 +51,7 @@ export default function TryItPage() {
                 <Alert color="purple" className="mt-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                     <div className="flex items-center gap-3 text-sm sm:text-base">
                         <FaLaptopCode className="text-xl" />
-                        <span>Need to walk through execution line-by-line? Open the interactive Code Visualizer.</span>
+                        <span>Need to walk through execution line-by-line? Open the interactive Python visualizer.</span>
                     </div>
                     <Button gradientDuoTone="purpleToBlue" as={Link} to="/visualizer">
                         <FaExternalLinkAlt className="mr-2" /> Launch Visualizer


### PR DESCRIPTION
## Summary
- add a Python tracing helper that captures execution events and expose a /visualize-python API endpoint
- rebuild the Code Visualizer page with an inline timeline, playback controls, and state inspector for the traced steps
- relabel navigation references to “Python Visualizer” and limit the editor shortcut to Python snippets

## Testing
- npm test
- npm run lint --prefix client *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68cc2517c878832dbc75fb519886e3fa