### PR TITLE
Add multi-language support to code visualizer

### DIFF
--- a/api/controllers/python.controller.js
+++ b/api/controllers/python.controller.js
@@ -10,6 +10,17 @@ import { errorHandler } from '../utils/error.js';
 const __dirname = path.resolve();
 const TEMP_DIR = path.join(__dirname, 'temp');
 const PYTHON_VISUALIZER_SCRIPT = path.join(__dirname, 'api', 'utils', 'python_visualizer.py');
+const PYTHON_TUTOR_ENDPOINT = 'https://pythontutor.com/webexec';
+
+const REMOTE_LANGUAGE_BACKENDS = {
+    java: 'java',
+    c: 'c',
+    cpp: 'cpp',
+    javascript: 'js',
+    typescript: 'ts',
+};
+
+const SUPPORTED_LANGUAGES = new Set(['python', ...Object.keys(REMOTE_LANGUAGE_BACKENDS)]);
 
 const execFileAsync = promisify(execFile);
 
@@ -78,10 +89,255 @@ const parseVisualizerPayload = (raw) => {
     }
 };
 
-export const visualizePythonCode = async (req, res, next) => {
-    const { code } = req.body;
+const sanitizeLanguage = (language) => {
+    if (!language || typeof language !== 'string') {
+        return 'python';
+    }
+    const lower = language.toLowerCase();
+    if (SUPPORTED_LANGUAGES.has(lower)) {
+        return lower;
+    }
+    return 'python';
+};
+
+const buildTutorRequestBody = (code, backend) => {
+    const params = new URLSearchParams();
+    params.set('user_script', code);
+    params.set('raw_input_json', '[]');
+    params.set(
+        'options_json',
+        JSON.stringify({
+            cumulative_mode: false,
+            heap_primitives: false,
+            show_only_outputs: false,
+            origin: 'scientistshield-visualizer',
+            backend,
+        }),
+    );
+    return params;
+};
+
+const formatTutorHeapEntry = (entry, heap, seen = new Set()) => {
+    if (!Array.isArray(entry) || entry.length === 0) {
+        return JSON.stringify(entry ?? null);
+    }
+
+    const [tag, ...rest] = entry;
+    const normalized = typeof tag === 'string' ? tag.toLowerCase() : '';
+
+    if (normalized === 'list' || normalized === 'tuple' || normalized === 'set') {
+        const open = normalized === 'tuple' ? '(' : normalized === 'set' ? '{' : '[';
+        const close = normalized === 'tuple' ? ')' : normalized === 'set' ? '}' : ']';
+        const values = rest.map((item) => formatTutorValue(item, heap, new Set(seen)));
+        return `${open}${values.join(', ')}${close}`;
+    }
+
+    if (normalized === 'dict') {
+        const pairs = rest
+            .map((pair) => {
+                if (!Array.isArray(pair) || pair.length < 2) {
+                    return JSON.stringify(pair);
+                }
+                const [key, value] = pair;
+                const keyText = formatTutorValue(key, heap, new Set(seen));
+                const valueText = formatTutorValue(value, heap, new Set(seen));
+                return `${keyText}: ${valueText}`;
+            })
+            .filter(Boolean);
+        return `{${pairs.join(', ')}}`;
+    }
+
+    if (normalized === 'instance') {
+        const className = rest[0] ?? 'instance';
+        const attributes = rest[1];
+        if (attributes && typeof attributes === 'object') {
+            const attrPairs = Object.entries(attributes).map(([name, value]) => {
+                const valueText = formatTutorValue(value, heap, new Set(seen));
+                return `${name}=${valueText}`;
+            });
+            return `${className}(${attrPairs.join(', ')})`;
+        }
+        return String(className);
+    }
+
+    return JSON.stringify(entry);
+};
+
+const formatTutorValue = (value, heap, seen = new Set()) => {
+    if (!Array.isArray(value)) {
+        if (typeof value === 'string') {
+            return value;
+        }
+        if (value === null) {
+            return 'null';
+        }
+        if (typeof value === 'number' || typeof value === 'boolean') {
+            return String(value);
+        }
+        return JSON.stringify(value);
+    }
+
+    if (value.length === 0) {
+        return '';
+    }
+
+    const [tag, ...rest] = value;
+    const normalized = typeof tag === 'string' ? tag.toLowerCase() : '';
+
+    if (normalized === 'ref') {
+        const refId = String(rest[0]);
+        if (seen.has(refId)) {
+            return `[ref ${refId}]`;
+        }
+        seen.add(refId);
+        const referenced = heap?.[refId];
+        if (!referenced) {
+            return `[ref ${refId}]`;
+        }
+        return formatTutorHeapEntry(referenced, heap, seen);
+    }
+
+    if (normalized === 'str' || normalized === 'string') {
+        return rest[0] ?? '';
+    }
+
+    if (['num', 'int', 'float', 'number'].includes(normalized)) {
+        return String(rest[0]);
+    }
+
+    if (normalized === 'bool') {
+        return rest[0] ? 'true' : 'false';
+    }
+
+    if (normalized === 'none') {
+        return 'None';
+    }
+
+    if (normalized === 'undefined') {
+        return 'undefined';
+    }
+
+    if (normalized === 'null') {
+        return 'null';
+    }
+
+    return JSON.stringify(value);
+};
+
+const transformTutorTrace = (traceEntries) => {
+    if (!Array.isArray(traceEntries)) {
+        return [];
+    }
+
+    return traceEntries.map((entry) => {
+        const stackFrames = Array.isArray(entry.stack_to_render)
+            ? entry.stack_to_render.map((frame) => ({
+                  function: frame?.func_name || frame?.name || '<module>',
+                  line: typeof frame?.line === 'number' ? frame.line : entry.line ?? null,
+              }))
+            : [];
+
+        const activeFrame = Array.isArray(entry.stack_to_render)
+            ? entry.stack_to_render.find((frame) => frame?.is_highlighted) || entry.stack_to_render[0] || null
+            : null;
+
+        const frameLocals = (activeFrame && activeFrame.locals) || entry.locals || {};
+        const heap = entry.heap || {};
+        const locals = {};
+        if (frameLocals && typeof frameLocals === 'object') {
+            Object.entries(frameLocals).forEach(([name, value]) => {
+                locals[name] = formatTutorValue(value, heap);
+            });
+        }
+
+        const stdout =
+            entry.stdout ||
+            entry.stdOut ||
+            entry.std_out ||
+            entry.output ||
+            (typeof entry.print_output === 'string' ? entry.print_output : '');
+
+        const transformed = {
+            event: entry.event || 'line',
+            line: typeof entry.line === 'number' ? entry.line : null,
+            function: entry.func_name || activeFrame?.func_name || '<module>',
+            locals,
+            stack: stackFrames,
+            stdout,
+            memory: { frames: [], objects: [] },
+        };
+
+        const returnValue = entry.return_val ?? entry.retval ?? entry.returnvalue;
+        if (returnValue !== undefined) {
+            transformed.returnValue = formatTutorValue(returnValue, heap);
+        }
+
+        const exceptionMessage = entry.exception_msg || entry.exception || entry.exceptionMessage;
+        if (exceptionMessage) {
+            transformed.exception = {
+                type: 'Exception',
+                message: String(exceptionMessage),
+            };
+        }
+
+        return transformed;
+    });
+};
+
+const visualizeWithPythonTutor = async (code, language) => {
+    const backend = REMOTE_LANGUAGE_BACKENDS[language];
+    if (!backend) {
+        throw errorHandler(400, 'Unsupported language for visualization.');
+    }
+
+    const body = buildTutorRequestBody(code, backend);
+    const response = await fetch(PYTHON_TUTOR_ENDPOINT, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body,
+    });
+
+    if (!response.ok) {
+        throw errorHandler(response.status, 'Python Tutor returned an error response.');
+    }
+
+    const payload = await response.json();
+    const events = transformTutorTrace(payload.trace || payload.event_trace || []);
+    const stdout =
+        payload.stdout ||
+        payload.stdOut ||
+        payload.std_out ||
+        payload.output ||
+        (typeof payload.code_output === 'string' ? payload.code_output : '');
+
+    const exceptionMessage = payload.exception_msg || payload.error;
+
+    return {
+        success: !exceptionMessage,
+        events,
+        stdout,
+        stderr: payload.stderr || '',
+        error: exceptionMessage ? { message: String(exceptionMessage) } : null,
+    };
+};
+
+export const visualizeCode = async (req, res, next) => {
+    const { code, language: requestedLanguage } = req.body;
     if (!code) {
-        return next(errorHandler(400, 'Python code is required.'));
+        return next(errorHandler(400, 'Code is required.'));
+    }
+
+    const language = sanitizeLanguage(requestedLanguage);
+
+    if (language !== 'python') {
+        try {
+            const result = await visualizeWithPythonTutor(code, language);
+            return res.status(200).json(result);
+        } catch (error) {
+            return next(error);
+        }
     }
 
     await fs.promises.mkdir(TEMP_DIR, { recursive: true });

--- a/api/routes/python.route.js
+++ b/api/routes/python.route.js
@@ -1,9 +1,10 @@
 import express from 'express';
-import { runPythonCode, visualizePythonCode } from '../controllers/python.controller.js';
+import { runPythonCode, visualizeCode } from '../controllers/python.controller.js';
 
 const router = express.Router();
 
 router.post('/run-python', runPythonCode);
-router.post('/visualize-python', visualizePythonCode);
+router.post('/visualize-python', visualizeCode);
+router.post('/visualize', visualizeCode);
 
 export default router;

--- a/client/src/components/BottomNav.jsx
+++ b/client/src/components/BottomNav.jsx
@@ -9,7 +9,7 @@ const items = [
     { to: '/', label: 'Home', icon: FaHome },
     { to: '/tutorials', label: 'Tutorials', icon: FaBook },
     { to: '/quizzes', label: 'Quizzes', icon: FaQuestionCircle },
-    { to: '/visualizer', label: 'Python Visualizer', icon: FaLaptopCode }
+    { to: '/visualizer', label: 'Code Visualizer', icon: FaLaptopCode }
 ];
 
 export default function BottomNav() {

--- a/client/src/components/CodeEditor.jsx
+++ b/client/src/components/CodeEditor.jsx
@@ -17,6 +17,8 @@ const defaultCodes = {
     python: `print("Hello, Python!")`
 };
 
+const visualizerSupportedLanguages = new Set(['python', 'cpp', 'javascript']);
+
 export default function CodeEditor({ initialCode = {}, language = 'html' }) {
     const { theme } = useSelector((state) => state.theme);
     const outputRef = useRef(null);
@@ -195,7 +197,7 @@ export default function CodeEditor({ initialCode = {}, language = 'html' }) {
                             <FaRedo className="mr-2 h-4 w-4" /> Reset
                         </Button>
                     </motion.div>
-                    {selectedLanguage === 'python' && (
+                    {visualizerSupportedLanguages.has(selectedLanguage) && (
                         <motion.div
                             whileHover={{ scale: 1.05 }}
                             whileTap={{ scale: 0.95 }}

--- a/client/src/components/CommandMenu.jsx
+++ b/client/src/components/CommandMenu.jsx
@@ -22,14 +22,14 @@ const CommandMenu = ({ isOpen, onClose }) => {
                 { label: 'Create a Tutorial', path: '/create-tutorial' },
                 { label: 'Create a Quiz', path: '/create-quiz' },
                 { label: 'Create a Page', path: '/create-page' },
-                { label: 'Python Visualizer', path: '/visualizer' },
+                { label: 'Code Visualizer', path: '/visualizer' },
             ];
         }
 
         return [
             { label: 'Profile', path: '/dashboard?tab=profile' },
             { label: 'Create a Post', path: '/create-post' },
-            { label: 'Python Visualizer', path: '/visualizer' },
+            { label: 'Code Visualizer', path: '/visualizer' },
         ];
     }, [currentUser]);
 

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -44,7 +44,7 @@ const navLinks = [
   { label: 'Home', path: '/' },
   { label: 'About', path: '/about' },
   { label: 'Projects', path: '/projects' },
-  { label: 'Python Visualizer', path: '/visualizer' },
+  { label: 'Code Visualizer', path: '/visualizer' },
 ];
 
 // --- Main Header Component ---

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -212,7 +212,7 @@ const Sidebar = ({ isCollapsed, isPinned, setIsPinned }) => {
         { to: '/tutorials', label: 'Tutorials', icon: FaBook },
         { to: '/quizzes', label: 'Quizzes', icon: FaQuestionCircle },
         { to: '/projects', label: 'Projects', icon: FaProjectDiagram },
-        { to: '/visualizer', label: 'Python Visualizer', icon: FaLaptopCode },
+        { to: '/visualizer', label: 'Code Visualizer', icon: FaLaptopCode },
         { to: '/invoices', label: 'Invoices', icon: FaRegFileAlt },
         { to: '/wallet', label: 'Wallet', icon: FaRegCreditCard },
         { to: '/notification', label: 'Notification', icon: FaRegBell },

--- a/client/src/pages/TryItPage.jsx
+++ b/client/src/pages/TryItPage.jsx
@@ -51,7 +51,7 @@ export default function TryItPage() {
                 <Alert color="purple" className="mt-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                     <div className="flex items-center gap-3 text-sm sm:text-base">
                         <FaLaptopCode className="text-xl" />
-                        <span>Need to walk through execution line-by-line? Open the interactive Python visualizer.</span>
+                        <span>Need to walk through execution line-by-line? Open the interactive code visualizer.</span>
                     </div>
                     <Button gradientDuoTone="purpleToBlue" as={Link} to="/visualizer">
                         <FaExternalLinkAlt className="mr-2" /> Launch Visualizer


### PR DESCRIPTION
## Summary
- extend the visualization API to delegate non-Python languages to Python Tutor while keeping the local Python tracer
- refresh the Code Visualizer UI with a language picker, per-language defaults, and updated messaging for the expanded support
- rename navigation links and editor actions to "Code Visualizer" so multi-language access is consistent across the app

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cc3a1eeadc832db1983705f938182d