### PR TITLE
Fix PostCard bookmark and share interactions

### DIFF
--- a/client/src/hooks/useBookmark.js
+++ b/client/src/hooks/useBookmark.js
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSelector } from 'react-redux';
 
@@ -20,43 +21,114 @@ const bookmarkPost = async (postId, token) => {
 export const useBookmark = (initialIsBookmarked, postId) => {
     const { currentUser } = useSelector((state) => state.user);
     const queryClient = useQueryClient();
+    const [isBookmarked, setIsBookmarked] = useState(!!initialIsBookmarked);
+
+    useEffect(() => {
+        setIsBookmarked(!!initialIsBookmarked);
+    }, [initialIsBookmarked]);
+
+    const updateBookmarkInPost = (post, shouldAdd, userId) => {
+        if (!post || post._id !== postId) return post;
+        const bookmarkedBy = Array.isArray(post.bookmarkedBy) ? post.bookmarkedBy : [];
+        const alreadyBookmarked = bookmarkedBy.includes(userId);
+
+        if (shouldAdd) {
+            if (alreadyBookmarked) return post;
+            return { ...post, bookmarkedBy: [...bookmarkedBy, userId] };
+        }
+
+        if (!alreadyBookmarked) return post;
+        return { ...post, bookmarkedBy: bookmarkedBy.filter(id => id !== userId) };
+    };
+
+    const updateBookmarkInCollection = (collection, shouldAdd, userId) => {
+        if (!collection) return collection;
+
+        if (Array.isArray(collection)) {
+            let hasChanged = false;
+            const updated = collection.map((item) => {
+                const next = updateBookmarkInPost(item, shouldAdd, userId);
+                if (next !== item) hasChanged = true;
+                return next;
+            });
+            return hasChanged ? updated : collection;
+        }
+
+        if (Array.isArray(collection.posts)) {
+            const updatedPosts = updateBookmarkInCollection(collection.posts, shouldAdd, userId);
+            if (updatedPosts === collection.posts) return collection;
+            return { ...collection, posts: updatedPosts };
+        }
+
+        if (Array.isArray(collection.pages)) {
+            let hasChanged = false;
+            const updatedPages = collection.pages.map((page) => {
+                const updatedPosts = updateBookmarkInCollection(page.posts, shouldAdd, userId);
+                if (updatedPosts !== page.posts) {
+                    hasChanged = true;
+                    return { ...page, posts: updatedPosts };
+                }
+                return page;
+            });
+            return hasChanged ? { ...collection, pages: updatedPages } : collection;
+        }
+
+        return updateBookmarkInPost(collection, shouldAdd, userId);
+    };
 
     const { mutate, isLoading } = useMutation({
-        mutationFn: () => bookmarkPost(postId, currentUser?.token),
+        mutationFn: () => {
+            if (!currentUser?.token || !currentUser?._id) {
+                return Promise.reject(new Error('You must be logged in to bookmark posts.'));
+            }
+            return bookmarkPost(postId, currentUser.token);
+        },
         onMutate: async () => {
-            await queryClient.cancelQueries({ queryKey: ['posts'] });
-            const previousPosts = queryClient.getQueryData(['posts']);
+            const userId = currentUser?._id;
+            if (!userId) {
+                return { postsQueries: [], postQueries: [] };
+            }
 
-            queryClient.setQueryData(['posts'], (oldData) => {
-                return oldData.map(p =>
-                    p._id === postId
-                        ? {
-                            ...p,
-                            bookmarkedBy: p.bookmarkedBy.includes(currentUser._id)
-                                ? p.bookmarkedBy.filter(id => id !== currentUser._id)
-                                : [...p.bookmarkedBy, currentUser._id],
-                        }
-                        : p
-                );
+            const shouldAdd = !isBookmarked;
+
+            await queryClient.cancelQueries({ queryKey: ['posts'] });
+            await queryClient.cancelQueries({ queryKey: ['post'] });
+
+            const postsQueries = queryClient.getQueriesData({ queryKey: ['posts'] });
+            const postQueries = queryClient.getQueriesData({ queryKey: ['post'] });
+
+            setIsBookmarked(prev => !prev);
+
+            postsQueries.forEach(([queryKey]) => {
+                queryClient.setQueryData(queryKey, (oldData) => updateBookmarkInCollection(oldData, shouldAdd, userId));
             });
 
-            return { previousPosts };
+            postQueries.forEach(([queryKey]) => {
+                queryClient.setQueryData(queryKey, (oldData) => updateBookmarkInCollection(oldData, shouldAdd, userId));
+            });
+
+            return { postsQueries, postQueries };
         },
-        onError: (err, variables, context) => {
-            if (context.previousPosts) {
-                queryClient.setQueryData(['posts'], context.previousPosts);
+        onError: (err, _variables, context) => {
+            setIsBookmarked(prev => !prev);
+            context?.postsQueries?.forEach(([queryKey, data]) => {
+                queryClient.setQueryData(queryKey, data);
+            });
+            context?.postQueries?.forEach(([queryKey, data]) => {
+                queryClient.setQueryData(queryKey, data);
+            });
+            console.error('Bookmark failed:', err);
+        },
+        onSuccess: (data) => {
+            if (typeof data?.isBookmarked === 'boolean') {
+                setIsBookmarked(data.isBookmarked);
             }
-            console.error("Bookmark failed:", err);
         },
         onSettled: () => {
             queryClient.invalidateQueries({ queryKey: ['posts'] });
+            queryClient.invalidateQueries({ queryKey: ['post'] });
         },
     });
-
-    const posts = queryClient.getQueryData(['posts']) || [];
-    const currentPostState = posts.find(p => p._id === postId);
-
-    const isBookmarked = currentPostState?.bookmarkedBy?.includes(currentUser?._id) ?? initialIsBookmarked;
 
     return { isBookmarked, isLoading, handleBookmark: mutate };
 };


### PR DESCRIPTION
## Summary
- enhance the PostCard share control with clipboard fallback, dynamic tooltip feedback, and robust cleanup
- rework the bookmark hook to track local state and safely update cached post collections

## Testing
- `npm run lint` *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d298434bb0832dab9ac09fb933c6e4